### PR TITLE
Implement environment setup for build and testing phase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Renode
+test/renode/
+
+# Python
+venv/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# PlatformIO
+.pio/
+.pioenvs/
+.piolibdeps/
+
+# Build
+build/
+
+# Robot Framework
+report.html
+log.html
+output.xml

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,8 +10,8 @@ The final plan to implement the `CONCEPT.md` and `DESIGN.md` to achieve the top 
 - [x] Select Technological Choices in `DESIGN.md` [2026-04-28]
 
 ## Phase 2: Environment Setup
-- [ ] Create `src/install.sh` for build tools
-- [ ] Create `test/install.sh` for test tools
+- [x] Create `src/install.sh` for build tools [2026-04-28]
+- [x] Create `test/install.sh` for test tools [2026-04-28]
 - [ ] Setup CI/CD Pipeline (Github Actions)
 - [ ] Verify CI/CD Pipeline with a dummy test
 

--- a/src/install.sh
+++ b/src/install.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Absolute path to the directory containing this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+pip install platformio

--- a/test/install.sh
+++ b/test/install.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+# Absolute path to the directory containing this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Install Renode 1.16.1
+RENODE_VERSION="1.16.1"
+RENODE_TAR="renode-${RENODE_VERSION}.linux-portable.tar.gz"
+RENODE_URL="https://github.com/renode/renode/releases/download/v${RENODE_VERSION}/${RENODE_TAR}"
+RENODE_DIR="${PROJECT_ROOT}/test/renode"
+
+if [ ! -d "$RENODE_DIR" ]; then
+    echo "Downloading and installing Renode ${RENODE_VERSION}..."
+    wget "$RENODE_URL"
+    mkdir -p "$RENODE_DIR"
+    tar -xzf "$RENODE_TAR" -C "$RENODE_DIR" --strip-components=1
+    rm "$RENODE_TAR"
+else
+    echo "Renode already installed in $RENODE_DIR"
+fi
+
+# Install Robot Framework and other dependencies
+pip install -r "${PROJECT_ROOT}/test/requirements.txt"

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,0 +1,8 @@
+robotframework==6.1
+robotframework-retryfailed==0.2.0
+psutil==5.9.3
+pyyaml==6.0.*
+telnetlib3==2.0.*
+construct==2.10.68
+pyelftools==0.30
+pillow>=10.0.0


### PR DESCRIPTION
In this task, I have implemented the "Environment Setup" phase as defined in the project's ROADMAP.md.

Specifically, I:
1.  Created the required directory structure: `specification/`, `src/`, and `test/`.
2.  Developed `src/install.sh` to automate the installation of PlatformIO.
3.  Developed `test/install.sh` to download and set up the portable version of Renode 1.16.1 and install the Robot Framework alongside other test dependencies. These scripts use absolute path resolution for increased robustness.
4.  Created `test/requirements.txt` containing the necessary Python packages for testing, modeled after the reference repository.
5.  Populated `.gitignore` with relevant entries to prevent large binaries and temporary build/test artifacts from being committed.
6.  Updated `ROADMAP.md` to mark the environment setup tasks as completed.

All changes have been verified by running the installation scripts and checking the versions of the installed tools.

Fixes #5

---
*PR created automatically by Jules for task [14193044532526003063](https://jules.google.com/task/14193044532526003063) started by @chatelao*