### PR TITLE
Fix Renode test environment and update UART verification

### DIFF
--- a/logs/verify_uart.Should_Print_Hello_World.fail0.log
+++ b/logs/verify_uart.Should_Print_Hello_World.fail0.log
@@ -1,0 +1,150 @@
+18:29:00.3826 [INFO] Including script(s): /app/test/renode-config/run_xiao.resc
+18:29:00.3973 [INFO] Script: Loading board initialization file
+18:29:00.4393 [INFO] System bus created.
+18:29:03.4951 [INFO] Including script(s): /app/test/renode-config/emulation/peripherals/clocks/rp2040_xosc.cs
+18:29:06.5191 [INFO] Including script(s): /app/test/renode-config/cores/initialize_peripherals_source.resc
+18:29:09.8551 [INFO] Including script(s): /app/test/renode-config/cores/initialize_peripherals_source.resc
+18:29:12.8636 [INFO] Including script(s): /app/test/renode-config/cores/initialize_peripherals_source.resc
+18:29:16.4070 [INFO] Including script(s): /app/test/renode-config/cores/initialize_peripherals_source.resc
+18:29:19.4181 [INFO] Including script(s): /app/test/renode-config/cores/initialize_peripherals_source.resc
+18:29:20.0384 [WARNING] Using alias 'id' for parameter 'cpuId'
+18:29:20.4213 [WARNING] Using alias 'id' for parameter 'cpuId' (3)
+18:29:21.2256 [INFO] [no-name]: Setting ROSC frequency to: 6MHz
+18:29:21.3090 [INFO] [no-name]: PIO0 successfuly created!
+18:29:21.3265 [INFO] [no-name]: PIO1 successfuly created!
+18:29:21.5058 [WARNING] Transmission finished in unexpected state: RecognizeOperation
+18:29:22.4597 [INFO] sysbus: Loaded SVD: /tmp/renode-154987/369b2920-92ae-4028-a4fe-cb24f95021a6.tmp. Name: RP2040. Description:
+        Dual-core Arm Cortex-M0+ processor, flexible clock running up to 133 MHz\n
+        264KB on-chip SRAM\n
+        2 x UART, 2 x SPI controllers, 2 x I2C controllers, 16 x PWM channels\n
+        1 x USB 1.1 controller and PHY, with host and device support\n
+        8 x Programmable I/O (PIO) state machines for custom peripheral support\n
+        Supported input power 1.8-5.5V DC\n
+        Operating temperature -20C to +85C\n
+        Drag-and-drop programming using mass storage over USB\n
+        Low-power sleep and dormant modes\n
+        Accurate on-chip clock\n
+        Temperature sensor\n
+        Accelerated integer and floating-point libraries on-chip
+      .
+18:29:24.1957 [INFO] sysbus: Loading block of 16384 bytes length at 0x0.
+18:29:24.2262 [INFO] sysbus: Loading block of 3052 bytes length at 0x50100400.
+18:29:24.2848 [INFO] piocpu0: Setting PC value to 0x0.
+18:29:24.2856 [INFO] piocpu1: Setting PC value to 0x0.
+18:29:24.2858 [INFO] Including script(s): /app/test/renode-config/tests/prepare.resc
+18:29:26.0850 [INFO] Script: Loading firmware file
+18:29:26.0965 [INFO] sysbus: Loading block of 71456 bytes length at 0x10000000.
+18:29:26.0966 [INFO] sysbus: Loading block of 9252 bytes length at 0x10011720.
+18:29:26.0967 [INFO] sysbus: Loading block of 192 bytes length at 0x20000000.
+18:29:26.0968 [INFO] sysbus: Loading block of 252700 bytes length at 0x200024E4.
+18:29:26.0970 [INFO] sysbus: Loading block of 2048 bytes length at 0x20040000.
+18:29:26.2305 [INFO] piocpu0: Setting PC value to 0x100030D5.
+18:29:26.2305 [INFO] piocpu1: Setting PC value to 0x100030D5.
+18:29:26.4388 [INFO] cpu1: Setting initial values: PC = 0xEB, SP = 0x20041F00.
+18:29:26.4462 [INFO] seeed_xiao_rp2040: Machine started.
+18:29:26.6946 [WARNING] sysbus: [cpu0: 0x3E] WriteDoubleWord of value 0x0 to an unimplemented register SYSCFG:PROC0_NMI_MASK (0x40004000) generated from SVD
+18:29:26.6951 [WARNING] sysbus: [cpu0: 0x40] WriteDoubleWord of value 0x0 to an unimplemented register SYSCFG:PROC1_NMI_MASK (0x40004004) generated from SVD
+18:29:26.6964 [WARNING] sysbus: [cpu0: 0xF8] ReadDoubleWord from an unimplemented register VREG_AND_CHIP_RESET:CHIP_RESET (0x40064008), returning a value from SVD: 0x0
+18:29:26.6970 [WARNING] sysbus: [cpu0: 0x19E] WriteDoubleWord to non existing peripheral at 0x4000F000, value 0x100.
+18:29:26.6985 [WARNING] sysbus: [cpu0: 0x1A0] (tag: 'RESET_DONE') ReadDoubleWord from non existing peripheral at 0x4000C008, returning 0xFFFFFFFF.
+18:29:26.7007 [WARNING] pads: Unhandled read from offset 0x6C (unknown).
+18:29:26.7009 [WARNING] pads: Unhandled write to offset 0x6C (unknown), value 0x0.
+18:29:26.7009 [WARNING] pads: Unhandled read from offset 0x70 (unknown).
+18:29:26.7009 [WARNING] pads: Unhandled write to offset 0x70 (unknown), value 0x0.
+18:29:26.7009 [WARNING] pads: Unhandled read from offset 0x74 (unknown).
+18:29:26.7009 [WARNING] pads: Unhandled write to offset 0x74 (unknown), value 0x0.
+18:29:26.7010 [WARNING] pads: Unhandled read from offset 0x78 (unknown).
+18:29:26.7010 [WARNING] pads: Unhandled write to offset 0x78 (unknown), value 0x0.
+18:29:26.7014 [WARNING] sysbus: [cpu0: 0x198] WriteDoubleWord to non existing peripheral at 0x4000E000, value 0x200240.
+18:29:26.7014 [WARNING] sysbus: [cpu0: 0x19E] WriteDoubleWord to non existing peripheral at 0x4000F000, value 0x200240.
+18:29:26.7015 [WARNING] sysbus: [cpu0: 0x1A0] (tag: 'RESET_DONE') ReadDoubleWord from non existing peripheral at 0x4000C008, returning 0xFFFFFFFF.
+18:29:26.7015 [WARNING] sysbus: [cpu0: 0x24DC] ReadDoubleWord from an unimplemented register TBMAN:PLATFORM (0x4006C000), returning a value from SVD: 0x5
+18:29:26.7020 [WARNING] sysbus: [cpu0: 0x198] WriteDoubleWord to non existing peripheral at 0x4000E000, value 0x240.
+18:29:26.7020 [WARNING] sysbus: [cpu0: 0x19E] WriteDoubleWord to non existing peripheral at 0x4000F000, value 0x240.
+18:29:26.7020 [WARNING] sysbus: [cpu0: 0x1A0] (tag: 'RESET_DONE') ReadDoubleWord from non existing peripheral at 0x4000C008, returning 0xFFFFFFFF.
+18:29:26.7104 [WARNING] xip_ssi.xip_flash: Transmission finished in unexpected state: RecognizeOperation
+18:29:26.7257 [WARNING] xip_ssi.xip_flash: Transmission finished in unexpected state: RecognizeOperation
+18:29:26.7258 [WARNING] xip_ssi.xip_flash: Unhandled operation: 0x0
+18:29:26.7263 [WARNING] xip_ssi.xip_flash: Unhandled operation while processing byte: 0x0
+18:29:26.7340 [WARNING] xip_ssi.xip_flash: Unhandled operation while processing byte: 0x0 (2)
+18:29:26.7340 [WARNING] xip_ssi.xip_flash: Unhandled operation while processing byte: 0x0
+18:29:26.7341 [WARNING] xip_ssi.xip_flash: Unhandled operation while processing byte: 0x0
+18:29:26.7438 [WARNING] xip_ssi.xip_flash: Unhandled operation while processing byte: 0x0 (2)
+18:29:26.7439 [WARNING] xip_ssi.xip_flash: Unhandled operation: 0xFF
+18:29:26.7454 [WARNING] xip_ssi.xip_flash: Unhandled operation while processing byte: 0x0
+18:29:26.7457 [WARNING] xip_ssi.xip_flash: Transmission finished in unexpected state: RecognizeOperation
+18:29:27.3940 [WARNING] sysbus: [cpu0: 0x2358] WriteDoubleWord of value 0x1 to an unimplemented register XIP_CTRL:FLUSH (0x14000004) generated from SVD
+18:29:27.3940 [WARNING] sysbus: [cpu0: 0x235A] ReadDoubleWord from an unimplemented register XIP_CTRL:FLUSH (0x14000004), returning a value from SVD: 0x0
+18:29:27.3940 [WARNING] sysbus: [cpu0: 0x2360] WriteDoubleWord to non existing peripheral at 0x14002000, value 0x1.
+18:29:27.4074 [WARNING] qspi_pads: Unhandled write to offset 0x4. Unhandled bits: [0] when writing value 0x21. Tags: SLEWFAST (0x1).
+18:29:27.4077 [WARNING] xip_ssi.xip_flash: Transmission finished in unexpected state: RecognizeOperation
+18:29:27.4114 [WARNING] xip_ssi.xip_flash: Unhandled operation while processing byte: 0x7
+18:29:27.4249 [WARNING] xip_ssi.xip_flash: Unhandled operation while processing byte: 0x7 (6)
+18:29:27.4250 [WARNING] sysbus: [cpu0: 0x10006642] WriteDoubleWord to non existing peripheral at 0x4000E000, value 0xFEFBCDBF.
+18:29:27.4250 [WARNING] sysbus: [cpu0: 0x10006648] WriteDoubleWord to non existing peripheral at 0x4000F000, value 0x3C7FFE.
+18:29:27.4250 [WARNING] sysbus: [cpu0: 0x1000664C] (tag: 'RESET_DONE') ReadDoubleWord from non existing peripheral at 0x4000C008, returning 0xFFFFFFFF.
+18:29:27.4251 [WARNING] sysbus: [cpu0: 0x1000666A] ReadDoubleWord from an unimplemented register USBCTRL_REGS:SIE_CTRL (0x5011004C), returning a value from SVD: 0x0
+18:29:27.4251 [WARNING] sysbus: [cpu0: 0x10006676] WriteDoubleWord to non existing peripheral at 0x5011204C, value 0x40000.
+18:29:27.4336 [WARNING] sysbus: [cpu0: 0x100051A0] WriteDoubleWord to non existing peripheral at 0x4000E000, value 0x1000.
+18:29:27.4336 [WARNING] sysbus: [cpu0: 0x100051A4] WriteDoubleWord to non existing peripheral at 0x4000F000, value 0x1000.
+18:29:27.4336 [WARNING] sysbus: [cpu0: 0x100051A8] (tag: 'RESET_DONE') ReadDoubleWord from non existing peripheral at 0x4000C008, returning 0xFFFFFFFF.
+18:29:27.4346 [WARNING] sysbus: [cpu0: 0x100051A0] WriteDoubleWord to non existing peripheral at 0x4000E000, value 0x2000.
+18:29:27.4346 [WARNING] sysbus: [cpu0: 0x100051A4] WriteDoubleWord to non existing peripheral at 0x4000F000, value 0x2000.
+18:29:27.4346 [WARNING] sysbus: [cpu0: 0x100051A8] (tag: 'RESET_DONE') ReadDoubleWord from non existing peripheral at 0x4000C008, returning 0xFFFFFFFF.
+18:29:27.4356 [WARNING] clocks: Unhandled write to offset 0x30. Unhandled bits: [11] when writing value 0x802. Tags: RESERVED (0x10).
+18:29:27.4362 [WARNING] clocks: Unhandled write to offset 0x3C. Unhandled bits: [11] when writing value 0x801. Tags: RESERVED (0x8).
+18:29:27.4400 [WARNING] clocks: Unhandled read from offset 0x4C (CLK_PERI_CTRL+0x4).
+18:29:27.4401 [WARNING] clocks: Unhandled write to offset 0x4C (CLK_PERI_CTRL+0x4), value 0x100.
+18:29:27.4466 [WARNING] clocks: Unhandled write to offset 0x4C (CLK_PERI_CTRL+0x4), value 0x100.
+18:29:27.4466 [WARNING] sysbus: [cpu0: 0x10006688] WriteDoubleWord to non existing peripheral at 0x4000F000, value 0x1FFFFFF.
+18:29:27.4467 [WARNING] sysbus: [cpu0: 0x1000668C] (tag: 'RESET_DONE') ReadDoubleWord from non existing peripheral at 0x4000C008, returning 0xFFFFFFFF.
+18:29:27.4467 [WARNING] pads: Unhandled read from offset 0x78 (unknown).
+18:29:27.4467 [WARNING] pads: Unhandled write to offset 0x78 (unknown), value 0x0.
+18:29:27.4467 [WARNING] pads: Unhandled read from offset 0x74 (unknown).
+18:29:27.4467 [WARNING] pads: Unhandled write to offset 0x74 (unknown), value 0x0.
+18:29:27.4468 [WARNING] pads: Unhandled read from offset 0x70 (unknown).
+18:29:27.4468 [WARNING] pads: Unhandled write to offset 0x70 (unknown), value 0x0.
+18:29:27.4468 [WARNING] pads: Unhandled read from offset 0x6C (unknown).
+18:29:27.4468 [WARNING] pads: Unhandled write to offset 0x6C (unknown), value 0x0.
+18:29:27.4635 [WARNING] sysbus: [cpu0: 0x198] WriteDoubleWord to non existing peripheral at 0x4000E000, value 0x240.
+18:29:27.4635 [WARNING] sysbus: [cpu0: 0x19E] WriteDoubleWord to non existing peripheral at 0x4000F000, value 0x240.
+18:29:27.4636 [WARNING] sysbus: [cpu0: 0x1A0] (tag: 'RESET_DONE') ReadDoubleWord from non existing peripheral at 0x4000C008, returning 0xFFFFFFFF.
+18:29:27.4638 [WARNING] xip_ssi.xip_flash: Transmission finished in unexpected state: RecognizeOperation
+18:29:27.5027 [WARNING] xip_ssi.xip_flash: Transmission finished in unexpected state: RecognizeOperation
+18:29:27.5028 [WARNING] xip_ssi.xip_flash: Unhandled operation: 0xFF
+18:29:27.5030 [WARNING] xip_ssi.xip_flash: Unhandled operation while processing byte: 0x0
+18:29:27.5037 [WARNING] xip_ssi.xip_flash: Unhandled operation: 0x4B
+18:29:27.5048 [WARNING] xip_ssi.xip_flash: Unhandled operation while processing byte: 0x0
+18:29:27.5051 [WARNING] xip_ssi.xip_flash: Unhandled operation while processing byte: 0x0
+18:29:27.5056 [WARNING] xip_ssi.xip_flash: Unhandled operation while processing byte: 0x0 (3)
+18:29:27.5056 [WARNING] xip_ssi.xip_flash: Unhandled operation while processing byte: 0x0
+18:29:27.5056 [WARNING] xip_ssi.xip_flash: Unhandled operation while processing byte: 0x0
+18:29:27.5060 [WARNING] xip_ssi.xip_flash: Unhandled operation while processing byte: 0x0
+18:29:27.5060 [WARNING] sysbus: [cpu0: 0x2358] WriteDoubleWord of value 0x1 to an unimplemented register XIP_CTRL:FLUSH (0x14000004) generated from SVD
+18:29:27.5061 [WARNING] sysbus: [cpu0: 0x235A] ReadDoubleWord from an unimplemented register XIP_CTRL:FLUSH (0x14000004), returning a value from SVD: 0x0
+18:29:27.5061 [WARNING] sysbus: [cpu0: 0x2360] WriteDoubleWord to non existing peripheral at 0x14002000, value 0x1.
+18:29:27.5063 [WARNING] qspi_pads: Unhandled write to offset 0x4. Unhandled bits: [0] when writing value 0x21. Tags: SLEWFAST (0x1).
+18:29:27.5065 [WARNING] xip_ssi.xip_flash: Transmission finished in unexpected state: RecognizeOperation
+18:29:27.5067 [WARNING] xip_ssi.xip_flash: Unhandled operation while processing byte: 0x7
+18:29:27.5146 [WARNING] xip_ssi.xip_flash: Unhandled operation while processing byte: 0x7 (6)
+18:29:27.5146 [WARNING] clocks: Unhandled write to offset 0x3C. Unhandled bits: [11] when writing value 0x821. Tags: RESERVED (0x8).
+18:29:27.5149 [WARNING] sysbus: [cpu0: 0x100051A0] WriteDoubleWord to non existing peripheral at 0x4000E000, value 0x1000.
+18:29:27.5149 [WARNING] sysbus: [cpu0: 0x100051A4] WriteDoubleWord to non existing peripheral at 0x4000F000, value 0x1000.
+18:29:27.5149 [WARNING] sysbus: [cpu0: 0x100051A8] (tag: 'RESET_DONE') ReadDoubleWord from non existing peripheral at 0x4000C008, returning 0xFFFFFFFF.
+18:29:27.5153 [WARNING] clocks: Unhandled write to offset 0x30. Unhandled bits: [11] when writing value 0x802. Tags: RESERVED (0x10).
+18:29:27.5156 [WARNING] clocks: Unhandled write to offset 0x3C. Unhandled bits: [11] when writing value 0x801. Tags: RESERVED (0x8).
+18:29:27.5157 [WARNING] clocks: Unhandled read from offset 0x4C (CLK_PERI_CTRL+0x4).
+18:29:27.5157 [WARNING] clocks: Unhandled write to offset 0x4C (CLK_PERI_CTRL+0x4), value 0x100.
+18:29:27.5199 [WARNING] clocks: Unhandled write to offset 0x4C (CLK_PERI_CTRL+0x4), value 0x100.
+18:29:27.5199 [WARNING] sysbus: [cpu0: 0x10008CC0] WriteDoubleWord to non existing peripheral at 0x4000E000, value 0x1000000.
+18:29:27.5199 [WARNING] sysbus: [cpu0: 0x10008CC6] WriteDoubleWord to non existing peripheral at 0x4000F000, value 0x1000000.
+18:29:27.5199 [WARNING] sysbus: [cpu0: 0x10008CCA] (tag: 'RESET_DONE') ReadDoubleWord from non existing peripheral at 0x4000C008, returning 0xFFFFFFFF.
+18:29:27.5200 [WARNING] sysbus: [cpu0: 0x10008CDE] WriteDoubleWord of value 0x9 to an unimplemented register USBCTRL_REGS:USB_MUXING (0x50110074) generated from SVD
+18:29:27.5201 [WARNING] sysbus: [cpu0: 0x10008B58] WriteDoubleWord of value 0xC to an unimplemented register USBCTRL_REGS:USB_PWR (0x50110078) generated from SVD
+18:29:27.5212 [WARNING] sysbus: [cpu0: 0x10008B86] WriteDoubleWord of value 0x1 to an unimplemented register USBCTRL_REGS:MAIN_CTRL (0x50110040) generated from SVD
+18:29:27.5212 [WARNING] sysbus: [cpu0: 0x10008B8E] WriteDoubleWord of value 0x20000000 to an unimplemented register USBCTRL_REGS:SIE_CTRL (0x5011004C) generated from SVD
+18:29:27.5213 [WARNING] sysbus: [cpu0: 0x10008B94] WriteDoubleWord of value 0x1D010 to an unimplemented register USBCTRL_REGS:INTE (0x50110090) generated from SVD
+18:29:27.5213 [WARNING] sysbus: [cpu0: 0x10008B9A] WriteDoubleWord to non existing peripheral at 0x5011204C, value 0x10000.
+18:29:27.5361 [WARNING] sio: Unhandled write to offset 0x50. Unhandled bits: [4-7] when writing value 0xFF. Tags: RESERVED (0xF).
+18:30:30.4833 [INFO] seeed_xiao_rp2040: Machine paused.
+18:30:32.5191 [INFO] seeed_xiao_rp2040: Machine resumed.

--- a/robot_output.xml
+++ b/robot_output.xml
@@ -1,46 +1,738 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<robot generator="Rebot 6.1 (Python 3.12.13 on linux)" generated="20260430 13:30:25.041" rpa="false" schemaversion="4">
+<robot generator="Rebot 6.1 (Python 3.12.13 on linux)" generated="20260430 18:30:32.938" rpa="false" schemaversion="4">
 <suite id="s1" name="Test Suite" source="/app/test/verify_uart.robot">
-<kw name="Setup" type="SETUP">
-<msg timestamp="20260430 13:30:25.000" level="TRACE">Arguments: [  ]</msg>
-<kw name="Set Variable" library="BuiltIn">
-<var>${RENODE_PATH}</var>
-<arg>/app/test/renode/renode</arg>
-<doc>Returns the given values which can then be assigned to a variables.</doc>
-<msg timestamp="20260430 13:30:25.000" level="TRACE">Arguments: [ '/app/test/renode/renode' ]</msg>
-<msg timestamp="20260430 13:30:25.000" level="TRACE">Return: '/app/test/renode/renode'</msg>
-<msg timestamp="20260430 13:30:25.000" level="INFO">${RENODE_PATH} = /app/test/renode/renode</msg>
-<status status="PASS" starttime="20260430 13:30:25.000" endtime="20260430 13:30:25.000"/>
+<kw name="Setup" library="renode-keywords" type="SETUP">
+<msg timestamp="20260430 18:28:59.542" level="TRACE">Arguments: [  ]</msg>
+<kw name="Evaluate" library="BuiltIn">
+<var>${SYSTEM}</var>
+<arg>platform.system()</arg>
+<arg>modules=platform</arg>
+<doc>Evaluates the given expression in Python and returns the result.</doc>
+<msg timestamp="20260430 18:28:59.543" level="TRACE">Arguments: [ 'platform.system()' | modules='platform' ]</msg>
+<msg timestamp="20260430 18:28:59.543" level="TRACE">Return: 'Linux'</msg>
+<msg timestamp="20260430 18:28:59.543" level="INFO">${SYSTEM} = Linux</msg>
+<status status="PASS" starttime="20260430 18:28:59.543" endtime="20260430 18:28:59.543"/>
 </kw>
+<kw name="Set Variable If" library="BuiltIn">
+<var>${CONFIGURATION}</var>
+<arg>not ${SKIP_RUNNING_SERVER} and ${SERVER_REMOTE_DEBUG}</arg>
+<arg>Debug</arg>
+<arg>${CONFIGURATION}</arg>
+<doc>Sets variable based on the given condition.</doc>
+<msg timestamp="20260430 18:28:59.544" level="TRACE">Arguments: [ 'not True and False' | 'Debug' | '${CONFIGURATION}' ]</msg>
+<msg timestamp="20260430 18:28:59.544" level="TRACE">Return: 'Release'</msg>
+<msg timestamp="20260430 18:28:59.544" level="INFO">${CONFIGURATION} = Release</msg>
+<status status="PASS" starttime="20260430 18:28:59.544" endtime="20260430 18:28:59.544"/>
+</kw>
+<kw name="Create List" library="BuiltIn">
+<var>@{PARAMS}</var>
+<arg>--robot-server-port</arg>
+<arg>${PORT_NUMBER}</arg>
+<arg>--hide-log</arg>
+<doc>Returns a list containing given items.</doc>
+<msg timestamp="20260430 18:28:59.545" level="TRACE">Arguments: [ '--robot-server-port' | '49152' | '--hide-log' ]</msg>
+<msg timestamp="20260430 18:28:59.545" level="TRACE">Return: ['--robot-server-port', '49152', '--hide-log']</msg>
+<msg timestamp="20260430 18:28:59.545" level="INFO">@{PARAMS} = [ --robot-server-port | 49152 | --hide-log ]</msg>
+<status status="PASS" starttime="20260430 18:28:59.544" endtime="20260430 18:28:59.545"/>
+</kw>
+<if>
+<branch type="IF" condition="${DISABLE_GUI}">
+<kw name="Insert Into List" library="Collections">
+<arg>${PARAMS}</arg>
+<arg>0</arg>
+<arg>--disable-gui</arg>
+<doc>Inserts ``value`` into ``list`` to the position specified with ``index``.</doc>
+<status status="NOT RUN" starttime="20260430 18:28:59.545" endtime="20260430 18:28:59.545"/>
+</kw>
+<status status="NOT RUN" starttime="20260430 18:28:59.545" endtime="20260430 18:28:59.545"/>
+</branch>
+<status status="PASS" starttime="20260430 18:28:59.545" endtime="20260430 18:28:59.545"/>
+</if>
+<if>
+<branch type="IF" condition="not ${SKIP_RUNNING_SERVER}">
+<kw name="File Should Exist" library="OperatingSystem">
+<arg>${DIRECTORY}/${BINARY_NAME}</arg>
+<arg>msg=Robot Framework remote server binary not found (${DIRECTORY}/${BINARY_NAME}). Did you forget to build it in ${CONFIGURATION} configuration?</arg>
+<doc>Fails unless the given ``path`` points to an existing file.</doc>
+<status status="NOT RUN" starttime="20260430 18:28:59.546" endtime="20260430 18:28:59.546"/>
+</kw>
+<status status="NOT RUN" starttime="20260430 18:28:59.545" endtime="20260430 18:28:59.546"/>
+</branch>
+<status status="PASS" starttime="20260430 18:28:59.545" endtime="20260430 18:28:59.546"/>
+</if>
+<if>
+<branch type="IF" condition="not ${SKIP_RUNNING_SERVER} and not ${SERVER_REMOTE_DEBUG} and not '${SYSTEM}' == 'Windows' and not ${NET_PLATFORM}">
+<kw name="Start Process" library="Process">
+<arg>mono</arg>
+<arg>${BINARY_NAME}</arg>
+<arg>@{PARAMS}</arg>
+<arg>cwd=${DIRECTORY}</arg>
+<doc>Starts a new process on background.</doc>
+<status status="NOT RUN" starttime="20260430 18:28:59.546" endtime="20260430 18:28:59.546"/>
+</kw>
+<status status="NOT RUN" starttime="20260430 18:28:59.546" endtime="20260430 18:28:59.546"/>
+</branch>
+<status status="PASS" starttime="20260430 18:28:59.546" endtime="20260430 18:28:59.546"/>
+</if>
+<if>
+<branch type="IF" condition="not ${SKIP_RUNNING_SERVER} and not ${SERVER_REMOTE_DEBUG} and '${SYSTEM}' == 'Windows'">
+<kw name="Start Process" library="Process">
+<arg>${BINARY_NAME}</arg>
+<arg>@{PARAMS}</arg>
+<arg>cwd=${DIRECTORY}</arg>
+<arg>shell=true</arg>
+<doc>Starts a new process on background.</doc>
+<status status="NOT RUN" starttime="20260430 18:28:59.547" endtime="20260430 18:28:59.547"/>
+</kw>
+<status status="NOT RUN" starttime="20260430 18:28:59.546" endtime="20260430 18:28:59.547"/>
+</branch>
+<status status="PASS" starttime="20260430 18:28:59.546" endtime="20260430 18:28:59.547"/>
+</if>
+<if>
+<branch type="IF" condition="not ${SKIP_RUNNING_SERVER} and not ${SERVER_REMOTE_DEBUG} and ${NET_PLATFORM}">
+<kw name="Start Process" library="Process">
+<arg>dotnet ${BINARY_NAME}</arg>
+<arg>@{PARAMS}</arg>
+<arg>cwd=${DIRECTORY}</arg>
+<arg>shell=true</arg>
+<doc>Starts a new process on background.</doc>
+<status status="NOT RUN" starttime="20260430 18:28:59.547" endtime="20260430 18:28:59.547"/>
+</kw>
+<status status="NOT RUN" starttime="20260430 18:28:59.547" endtime="20260430 18:28:59.547"/>
+</branch>
+<status status="PASS" starttime="20260430 18:28:59.547" endtime="20260430 18:28:59.547"/>
+</if>
+<if>
+<branch type="IF" condition="not ${SKIP_RUNNING_SERVER} and ${SERVER_REMOTE_DEBUG} and not '${SYSTEM}' == 'Windows' and not ${NET_PLATFORM}">
+<kw name="Start Process" library="Process">
+<arg>mono</arg>
+<arg>--debug</arg>
+<arg>--debugger-agent\=transport\=dt_socket,address\=0.0.0.0:${SERVER_REMOTE_PORT},server\=y,suspend\=${SERVER_REMOTE_SUSPEND}</arg>
+<arg>${BINARY_NAME}</arg>
+<arg>@{PARAMS}</arg>
+<arg>cwd=${DIRECTORY}</arg>
+<doc>Starts a new process on background.</doc>
+<status status="NOT RUN" starttime="20260430 18:28:59.548" endtime="20260430 18:28:59.548"/>
+</kw>
+<status status="NOT RUN" starttime="20260430 18:28:59.547" endtime="20260430 18:28:59.548"/>
+</branch>
+<status status="PASS" starttime="20260430 18:28:59.547" endtime="20260430 18:28:59.548"/>
+</if>
+<if>
+<branch type="IF" condition="not ${SKIP_RUNNING_SERVER} and ${SERVER_REMOTE_DEBUG} and '${SYSTEM}' == 'Windows'">
+<kw name="Fatal Error" library="BuiltIn">
+<arg>Windows doesn't support server remote debug option.</arg>
+<doc>Stops the whole test execution.</doc>
+<status status="NOT RUN" starttime="20260430 18:28:59.548" endtime="20260430 18:28:59.548"/>
+</kw>
+<status status="NOT RUN" starttime="20260430 18:28:59.548" endtime="20260430 18:28:59.548"/>
+</branch>
+<status status="PASS" starttime="20260430 18:28:59.548" endtime="20260430 18:28:59.548"/>
+</if>
+<if>
+<branch type="IF" condition="not '${SYSTEM}' == 'Windows'">
+<kw name="Wait Until Keyword Succeeds" library="BuiltIn">
+<arg>60s</arg>
+<arg>1s</arg>
+<arg>Import Library</arg>
+<arg>Remote</arg>
+<arg>http://127.0.0.1:${PORT_NUMBER}/</arg>
+<doc>Runs the specified keyword and retries if it fails.</doc>
+<msg timestamp="20260430 18:28:59.549" level="TRACE">Arguments: [ '60s' | '1s' | 'Import Library' | 'Remote' | 'http://127.0.0.1:${PORT_NUMBER}/' ]</msg>
+<kw name="Import Library" library="BuiltIn">
+<arg>Remote</arg>
+<arg>http://127.0.0.1:${PORT_NUMBER}/</arg>
+<doc>Imports a library with the given name and optional arguments.</doc>
+<msg timestamp="20260430 18:28:59.549" level="TRACE">Arguments: [ 'Remote' | 'http://127.0.0.1:${PORT_NUMBER}/' ]</msg>
+<msg timestamp="20260430 18:29:00.244" level="TRACE">Return: None</msg>
+<status status="PASS" starttime="20260430 18:28:59.549" endtime="20260430 18:29:00.244"/>
+</kw>
+<msg timestamp="20260430 18:29:00.244" level="TRACE">Return: None</msg>
+<status status="PASS" starttime="20260430 18:28:59.549" endtime="20260430 18:29:00.244"/>
+</kw>
+<status status="PASS" starttime="20260430 18:28:59.548" endtime="20260430 18:29:00.244"/>
+</branch>
+<status status="PASS" starttime="20260430 18:28:59.548" endtime="20260430 18:29:00.244"/>
+</if>
+<if>
+<branch type="IF" condition="'${SYSTEM}' == 'Windows'">
+<kw name="Wait Until Keyword Succeeds" library="BuiltIn">
+<arg>60s</arg>
+<arg>1s</arg>
+<arg>Import Library</arg>
+<arg>Remote</arg>
+<arg>http://localhost:${PORT_NUMBER}/</arg>
+<doc>Runs the specified keyword and retries if it fails.</doc>
+<status status="NOT RUN" starttime="20260430 18:29:00.245" endtime="20260430 18:29:00.245"/>
+</kw>
+<status status="NOT RUN" starttime="20260430 18:29:00.245" endtime="20260430 18:29:00.245"/>
+</branch>
+<status status="PASS" starttime="20260430 18:29:00.244" endtime="20260430 18:29:00.245"/>
+</if>
 <kw name="Setup Renode" library="renode-keywords">
-<arg>${RENODE_PATH}</arg>
-<msg timestamp="20260430 13:30:25.001" level="FAIL">Keyword 'renode-keywords.Setup Renode' expected 0 arguments, got 1.</msg>
-<status status="FAIL" starttime="20260430 13:30:25.001" endtime="20260430 13:30:25.001"/>
+<msg timestamp="20260430 18:29:00.245" level="TRACE">Arguments: [  ]</msg>
+<kw name="Set Default Uart Timeout" library="Remote">
+<arg>${DEFAULT_UART_TIMEOUT}</arg>
+<msg timestamp="20260430 18:29:00.246" level="TRACE">Arguments: [ '8' ]</msg>
+<msg timestamp="20260430 18:29:00.281" level="TRACE">Return: ''</msg>
+<status status="PASS" starttime="20260430 18:29:00.246" endtime="20260430 18:29:00.282"/>
 </kw>
-<status status="FAIL" starttime="20260430 13:30:25.000" endtime="20260430 13:30:25.001"/>
+<if>
+<branch type="IF" condition="${SAVE_LOGS}">
+<kw name="Enable Logging To Cache" library="Remote">
+<msg timestamp="20260430 18:29:00.282" level="TRACE">Arguments: [  ]</msg>
+<msg timestamp="20260430 18:29:00.290" level="TRACE">Return: ''</msg>
+<status status="PASS" starttime="20260430 18:29:00.282" endtime="20260430 18:29:00.290"/>
+</kw>
+<status status="PASS" starttime="20260430 18:29:00.282" endtime="20260430 18:29:00.290"/>
+</branch>
+<status status="PASS" starttime="20260430 18:29:00.282" endtime="20260430 18:29:00.291"/>
+</if>
+<kw name="Set Variable" library="BuiltIn">
+<var>${allowed_chars}</var>
+<arg>abcdefghijklmnopqrstuvwxyz01234567890_-</arg>
+<doc>Returns the given values which can then be assigned to a variables.</doc>
+<msg timestamp="20260430 18:29:00.291" level="TRACE">Arguments: [ 'abcdefghijklmnopqrstuvwxyz01234567890_-' ]</msg>
+<msg timestamp="20260430 18:29:00.291" level="TRACE">Return: 'abcdefghijklmnopqrstuvwxyz01234567890_-'</msg>
+<msg timestamp="20260430 18:29:00.291" level="INFO">${allowed_chars} = abcdefghijklmnopqrstuvwxyz01234567890_-</msg>
+<status status="PASS" starttime="20260430 18:29:00.291" endtime="20260430 18:29:00.291"/>
+</kw>
+<kw name="Convert To Lower Case" library="String">
+<var>${metrics_fname}</var>
+<arg>${SUITE_NAME}</arg>
+<doc>Converts string to lower case.</doc>
+<msg timestamp="20260430 18:29:00.291" level="TRACE">Arguments: [ 'verify_uart' ]</msg>
+<msg timestamp="20260430 18:29:00.291" level="TRACE">Return: 'verify_uart'</msg>
+<msg timestamp="20260430 18:29:00.292" level="INFO">${metrics_fname} = verify_uart</msg>
+<status status="PASS" starttime="20260430 18:29:00.291" endtime="20260430 18:29:00.292"/>
+</kw>
+<kw name="Replace String" library="String">
+<var>${metrics_fname}</var>
+<arg>${metrics_fname}</arg>
+<arg>${SPACE}</arg>
+<arg>_</arg>
+<doc>Replaces ``search_for`` in the given ``string`` with ``replace_with``.</doc>
+<msg timestamp="20260430 18:29:00.292" level="TRACE">Arguments: [ 'verify_uart' | ' ' | '_' ]</msg>
+<msg timestamp="20260430 18:29:00.292" level="TRACE">Return: 'verify_uart'</msg>
+<msg timestamp="20260430 18:29:00.292" level="INFO">${metrics_fname} = verify_uart</msg>
+<status status="PASS" starttime="20260430 18:29:00.292" endtime="20260430 18:29:00.292"/>
+</kw>
+<kw name="Replace String Using Regexp" library="String">
+<var>${metrics_fname}</var>
+<arg>${metrics_fname}</arg>
+<arg>[^${allowed_chars}]+</arg>
+<arg>${EMPTY}</arg>
+<doc>Replaces ``pattern`` in the given ``string`` with ``replace_with``.</doc>
+<msg timestamp="20260430 18:29:00.293" level="TRACE">Arguments: [ 'verify_uart' | '[^abcdefghijklmnopqrstuvwxyz01234567890_-]+' | '' ]</msg>
+<msg timestamp="20260430 18:29:00.293" level="TRACE">Return: 'verify_uart'</msg>
+<msg timestamp="20260430 18:29:00.293" level="INFO">${metrics_fname} = verify_uart</msg>
+<status status="PASS" starttime="20260430 18:29:00.292" endtime="20260430 18:29:00.293"/>
+</kw>
+<kw name="Join Path" library="OperatingSystem">
+<var>${metrics_path}</var>
+<arg>${RESULTS_DIRECTORY}</arg>
+<arg>profiler-${metrics_fname}</arg>
+<doc>Joins the given path part(s) to the given base path.</doc>
+<msg timestamp="20260430 18:29:00.294" level="TRACE">Arguments: [ '/app/' | 'profiler-verify_uart' ]</msg>
+<msg timestamp="20260430 18:29:00.294" level="TRACE">Return: '/app/profiler-verify_uart'</msg>
+<msg timestamp="20260430 18:29:00.294" level="INFO">${metrics_path} = /app/profiler-verify_uart</msg>
+<status status="PASS" starttime="20260430 18:29:00.294" endtime="20260430 18:29:00.294"/>
+</kw>
+<if>
+<branch type="IF" condition="${CREATE_EXECUTION_METRICS}">
+<kw name="Execute Command" library="Remote">
+<arg>EnableProfilerGlobally "${metrics_path}"</arg>
+<status status="NOT RUN" starttime="20260430 18:29:00.294" endtime="20260430 18:29:00.294"/>
+</kw>
+<status status="NOT RUN" starttime="20260430 18:29:00.294" endtime="20260430 18:29:00.294"/>
+</branch>
+<status status="PASS" starttime="20260430 18:29:00.294" endtime="20260430 18:29:00.294"/>
+</if>
+<kw name="Reset Emulation" library="Remote">
+<msg timestamp="20260430 18:29:00.295" level="TRACE">Arguments: [  ]</msg>
+<msg timestamp="20260430 18:29:00.326" level="TRACE">Return: ''</msg>
+<status status="PASS" starttime="20260430 18:29:00.295" endtime="20260430 18:29:00.326"/>
+</kw>
+<msg timestamp="20260430 18:29:00.326" level="TRACE">Return: None</msg>
+<status status="PASS" starttime="20260430 18:29:00.245" endtime="20260430 18:29:00.326"/>
+</kw>
+<msg timestamp="20260430 18:29:00.326" level="TRACE">Return: None</msg>
+<status status="PASS" starttime="20260430 18:28:59.542" endtime="20260430 18:29:00.326"/>
 </kw>
 <test id="s1-t1" name="Should Print Hello World" line="12">
-<status status="FAIL" starttime="20260430 13:30:25.001" endtime="20260430 13:30:25.002">Parent suite setup failed:
-Keyword 'renode-keywords.Setup Renode' expected 0 arguments, got 1.
-
-Also parent suite teardown failed:
-No keyword with name 'Teardown Renode' found. Did you try using keyword 'Teardown' or 'renode-keywords.Teardown' and forgot to use enough whitespace between keyword and arguments?</status>
-</test>
-<kw name="Teardown" type="TEARDOWN">
-<msg timestamp="20260430 13:30:25.003" level="TRACE">Arguments: [  ]</msg>
-<kw name="Teardown Renode">
-<msg timestamp="20260430 13:30:25.007" level="FAIL">No keyword with name 'Teardown Renode' found. Did you try using keyword 'Teardown' or 'renode-keywords.Teardown' and forgot to use enough whitespace between keyword and arguments?</msg>
-<status status="FAIL" starttime="20260430 13:30:25.007" endtime="20260430 13:30:25.007"/>
+<kw name="Reset Emulation" library="Remote" type="SETUP">
+<msg timestamp="20260430 18:29:00.327" level="TRACE">Arguments: [  ]</msg>
+<msg timestamp="20260430 18:29:00.334" level="TRACE">Return: ''</msg>
+<status status="PASS" starttime="20260430 18:29:00.327" endtime="20260430 18:29:00.334"/>
 </kw>
-<msg timestamp="20260430 13:30:25.007" level="TRACE">Return: None</msg>
-<status status="FAIL" starttime="20260430 13:30:25.003" endtime="20260430 13:30:25.007">No keyword with name 'Teardown Renode' found. Did you try using keyword 'Teardown' or 'renode-keywords.Teardown' and forgot to use enough whitespace between keyword and arguments?</status>
+<kw name="Create Machine">
+<msg timestamp="20260430 18:29:00.334" level="TRACE">Arguments: [  ]</msg>
+<kw name="Execute Command" library="Remote">
+<arg>$global.TEST_FILE = @${FIRMWARE}</arg>
+<msg timestamp="20260430 18:29:00.334" level="TRACE">Arguments: [ '$global.TEST_FILE = @/app/test/../.pio/build/seeed-xiao-rp2040/firmware.elf' ]</msg>
+<msg timestamp="20260430 18:29:00.359" level="TRACE">Return: ''</msg>
+<status status="PASS" starttime="20260430 18:29:00.334" endtime="20260430 18:29:00.359"/>
+</kw>
+<kw name="Execute Command" library="Remote">
+<arg>include @${RESC}</arg>
+<msg timestamp="20260430 18:29:00.359" level="TRACE">Arguments: [ 'include @/app/test/renode-config/run_xiao.resc' ]</msg>
+<msg timestamp="20260430 18:29:26.362" level="TRACE">Return: "Current 'PATH' value is: /app/test/renode-config;/app/test/renode;/app/test/renode/\n\n"</msg>
+<status status="PASS" starttime="20260430 18:29:00.359" endtime="20260430 18:29:26.363"/>
+</kw>
+<kw name="Create Terminal Tester" library="Remote">
+<arg>${UART}</arg>
+<msg timestamp="20260430 18:29:26.363" level="TRACE">Arguments: [ 'sysbus.uart0' ]</msg>
+<msg timestamp="20260430 18:29:26.385" level="TRACE">Return: 0</msg>
+<status status="PASS" starttime="20260430 18:29:26.363" endtime="20260430 18:29:26.386"/>
+</kw>
+<msg timestamp="20260430 18:29:26.386" level="TRACE">Return: None</msg>
+<status status="PASS" starttime="20260430 18:29:00.334" endtime="20260430 18:29:26.386"/>
+</kw>
+<kw name="Start Emulation" library="Remote">
+<msg timestamp="20260430 18:29:26.386" level="TRACE">Arguments: [  ]</msg>
+<msg timestamp="20260430 18:29:26.569" level="TRACE">Return: ''</msg>
+<status status="PASS" starttime="20260430 18:29:26.386" endtime="20260430 18:29:26.569"/>
+</kw>
+<kw name="Wait For Line On Uart" library="Remote">
+<arg>Hello from XIAO RP2040!</arg>
+<msg timestamp="20260430 18:29:26.570" level="TRACE">Arguments: [ 'Hello from XIAO RP2040!' ]</msg>
+<msg timestamp="20260430 18:30:30.446" level="FAIL">InvalidOperationException: Terminal tester failed!
+
+Full report:
+([host: 04/30/2026 18:29:26, virt:       0] Attached to UART event: success)
+ [[no newline]]
+([host: 04/30/2026 18:30:30, virt:    8000] Line containing &gt;&gt;Hello from XIAO RP2040!&lt;&lt; event: failure)
+
+</msg>
+<msg timestamp="20260430 18:30:30.446" level="DEBUG">InvalidOperationException:   at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&amp;)
+  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in &lt;aeea2e33ea654cfabae63b60ba0e127a&gt;:0
+</msg>
+<status status="FAIL" starttime="20260430 18:29:26.569" endtime="20260430 18:30:30.446"/>
+</kw>
+<kw name="Test Teardown" library="renode-keywords" type="TEARDOWN">
+<msg timestamp="20260430 18:30:30.447" level="TRACE">Arguments: [  ]</msg>
+<kw name="Stop Profiler" library="renode-keywords">
+<msg timestamp="20260430 18:30:30.448" level="TRACE">Arguments: [  ]</msg>
+<if>
+<branch type="IF" condition="${PROFILER_PROCESS}">
+<kw name="Terminate Process" library="Process">
+<arg>${PROFILER_PROCESS}</arg>
+<doc>Stops the process gracefully or forcefully.</doc>
+<status status="NOT RUN" starttime="20260430 18:30:30.448" endtime="20260430 18:30:30.448"/>
+</kw>
+<kw name="Set Test Variable" library="BuiltIn">
+<arg>${PROFILER_PROCESS}</arg>
+<arg>None</arg>
+<doc>Makes a variable available everywhere within the scope of the current test.</doc>
+<status status="NOT RUN" starttime="20260430 18:30:30.448" endtime="20260430 18:30:30.448"/>
+</kw>
+<status status="NOT RUN" starttime="20260430 18:30:30.448" endtime="20260430 18:30:30.448"/>
+</branch>
+<status status="PASS" starttime="20260430 18:30:30.448" endtime="20260430 18:30:30.448"/>
+</if>
+<msg timestamp="20260430 18:30:30.448" level="TRACE">Return: None</msg>
+<status status="PASS" starttime="20260430 18:30:30.447" endtime="20260430 18:30:30.448"/>
+</kw>
+<kw name="Run Keyword If Test Failed" library="BuiltIn">
+<var>${failed}</var>
+<arg>Set Variable</arg>
+<arg>True</arg>
+<doc>Runs the given keyword with the given arguments, if the test failed.</doc>
+<msg timestamp="20260430 18:30:30.449" level="TRACE">Arguments: [ 'Set Variable' | 'True' ]</msg>
+<kw name="Set Variable" library="BuiltIn">
+<arg>True</arg>
+<doc>Returns the given values which can then be assigned to a variables.</doc>
+<msg timestamp="20260430 18:30:30.449" level="TRACE">Arguments: [ 'True' ]</msg>
+<msg timestamp="20260430 18:30:30.449" level="TRACE">Return: 'True'</msg>
+<status status="PASS" starttime="20260430 18:30:30.449" endtime="20260430 18:30:30.449"/>
+</kw>
+<msg timestamp="20260430 18:30:30.449" level="TRACE">Return: 'True'</msg>
+<msg timestamp="20260430 18:30:30.450" level="INFO">${failed} = True</msg>
+<status status="PASS" starttime="20260430 18:30:30.449" endtime="20260430 18:30:30.450"/>
+</kw>
+<if>
+<branch type="IF" condition="${failed}">
+<kw name="Strip String" library="String">
+<var>${message}</var>
+<arg>${TEST_MESSAGE}</arg>
+<arg>mode=right</arg>
+<doc>Remove leading and/or trailing whitespaces from the given string.</doc>
+<msg timestamp="20260430 18:30:30.450" level="TRACE">Arguments: [ 'InvalidOperationException: Terminal tester failed!\n\nFull report:\n([host: 04/30/2026 18:29:26, virt:       0] Attached to UART event: success)\n [[no newline]]\n([host: 04/30/2026 18:30:30, virt:    8000] Line containing &gt;&gt;Hello from XIAO RP2040!&lt;&lt; event: failure)\n\n' | mode='right' ]</msg>
+<msg timestamp="20260430 18:30:30.450" level="TRACE">Return: 'InvalidOperationException: Terminal tester failed!\n\nFull report:\n([host: 04/30/2026 18:29:26, virt:       0] Attached to UART event: success)\n [[no newline]]\n([host: 04/30/2026 18:30:30, virt:    8000] Line containing &gt;&gt;Hello from XIAO RP2040!&lt;&lt; event: failure)'</msg>
+<msg timestamp="20260430 18:30:30.450" level="INFO">${message} = InvalidOperationException: Terminal tester failed!
+
+Full report:
+([host: 04/30/2026 18:29:26, virt:       0] Attached to UART event: success)
+ [[no newline]]
+([host: 04/30/2026 18:30:30, virt:    8000...</msg>
+<status status="PASS" starttime="20260430 18:30:30.450" endtime="20260430 18:30:30.450"/>
+</kw>
+<kw name="Set Test Message" library="BuiltIn">
+<arg>${message}</arg>
+<doc>Sets message for the current test case.</doc>
+<msg timestamp="20260430 18:30:30.451" level="TRACE">Arguments: [ 'InvalidOperationException: Terminal tester failed!\n\nFull report:\n([host: 04/30/2026 18:29:26, virt:       0] Attached to UART event: success)\n [[no newline]]\n([host: 04/30/2026 18:30:30, virt:    8000] Line containing &gt;&gt;Hello from XIAO RP2040!&lt;&lt; event: failure)' ]</msg>
+<msg timestamp="20260430 18:30:30.451" level="INFO">Set test message to:
+InvalidOperationException: Terminal tester failed!
+
+Full report:
+([host: 04/30/2026 18:29:26, virt:       0] Attached to UART event: success)
+ [[no newline]]
+([host: 04/30/2026 18:30:30, virt:    8000] Line containing &gt;&gt;Hello from XIAO RP2040!&lt;&lt; event: failure)</msg>
+<msg timestamp="20260430 18:30:30.451" level="TRACE">Return: None</msg>
+<status status="PASS" starttime="20260430 18:30:30.450" endtime="20260430 18:30:30.451"/>
+</kw>
+<status status="PASS" starttime="20260430 18:30:30.450" endtime="20260430 18:30:30.451"/>
+</branch>
+<status status="PASS" starttime="20260430 18:30:30.450" endtime="20260430 18:30:30.451"/>
+</if>
+<kw name="Run Keyword If Timeout Occurred" library="BuiltIn">
+<var>${timed_out}</var>
+<arg>Set Variable</arg>
+<arg>True</arg>
+<doc>Runs the given keyword if either a test or a keyword timeout has occurred.</doc>
+<msg timestamp="20260430 18:30:30.451" level="TRACE">Arguments: [ 'Set Variable' | 'True' ]</msg>
+<msg timestamp="20260430 18:30:30.451" level="TRACE">Return: None</msg>
+<msg timestamp="20260430 18:30:30.451" level="INFO">${timed_out} = None</msg>
+<status status="PASS" starttime="20260430 18:30:30.451" endtime="20260430 18:30:30.451"/>
+</kw>
+<if>
+<branch type="IF" condition="${timed_out}">
+<return>
+<status status="NOT RUN" starttime="20260430 18:30:30.451" endtime="20260430 18:30:30.452"/>
+</return>
+<status status="NOT RUN" starttime="20260430 18:30:30.451" endtime="20260430 18:30:30.452"/>
+</branch>
+<status status="PASS" starttime="20260430 18:30:30.451" endtime="20260430 18:30:30.452"/>
+</if>
+<if>
+<branch type="IF" condition="${CREATE_SNAPSHOT_ON_FAIL}">
+<kw name="Run Keyword If Test Failed" library="BuiltIn">
+<arg>Create Snapshot Of Failed Test</arg>
+<doc>Runs the given keyword with the given arguments, if the test failed.</doc>
+<msg timestamp="20260430 18:30:30.452" level="TRACE">Arguments: [ 'Create Snapshot Of Failed Test' ]</msg>
+<kw name="Create Snapshot Of Failed Test" library="renode-keywords">
+<msg timestamp="20260430 18:30:30.452" level="TRACE">Arguments: [  ]</msg>
+<kw name="Return From Keyword If" library="BuiltIn">
+<arg>'skipped' in @{TEST TAGS}</arg>
+<doc>Returns from the enclosing user keyword if ``condition`` is true.</doc>
+<msg timestamp="20260430 18:30:30.453" level="TRACE">Arguments: [ "'skipped' in []" ]</msg>
+<msg timestamp="20260430 18:30:30.453" level="TRACE">Return: None</msg>
+<status status="PASS" starttime="20260430 18:30:30.452" endtime="20260430 18:30:30.453"/>
+</kw>
+<kw name="Get Variable Value" library="BuiltIn">
+<var>${retry_index}</var>
+<arg>\${RETRYFAILED_RETRY_INDEX}</arg>
+<arg>0</arg>
+<doc>Returns variable value or ``default`` if the variable does not exist.</doc>
+<msg timestamp="20260430 18:30:30.453" level="TRACE">Arguments: [ '\\${RETRYFAILED_RETRY_INDEX}' | '0' ]</msg>
+<msg timestamp="20260430 18:30:30.454" level="TRACE">Return: '0'</msg>
+<msg timestamp="20260430 18:30:30.454" level="INFO">${retry_index} = 0</msg>
+<status status="PASS" starttime="20260430 18:30:30.453" endtime="20260430 18:30:30.454"/>
+</kw>
+<kw name="Set Variable" library="BuiltIn">
+<var>${test_name}</var>
+<arg>${SUITE NAME}.${TEST NAME}.fail${retry_index}.save</arg>
+<doc>Returns the given values which can then be assigned to a variables.</doc>
+<msg timestamp="20260430 18:30:30.455" level="TRACE">Arguments: [ 'verify_uart.Should Print Hello World.fail0.save' ]</msg>
+<msg timestamp="20260430 18:30:30.455" level="TRACE">Return: 'verify_uart.Should Print Hello World.fail0.save'</msg>
+<msg timestamp="20260430 18:30:30.455" level="INFO">${test_name} = verify_uart.Should Print Hello World.fail0.save</msg>
+<status status="PASS" starttime="20260430 18:30:30.454" endtime="20260430 18:30:30.455"/>
+</kw>
+<kw name="Sanitize Test Name" library="renode-keywords">
+<var>${test_name}</var>
+<arg>${test_name}</arg>
+<msg timestamp="20260430 18:30:30.455" level="TRACE">Arguments: [ ${test_name}='verify_uart.Should Print Hello World.fail0.save' ]</msg>
+<kw name="Replace String" library="String">
+<var>${test_name}</var>
+<arg>${test_name}</arg>
+<arg>${SPACE}</arg>
+<arg>_</arg>
+<doc>Replaces ``search_for`` in the given ``string`` with ``replace_with``.</doc>
+<msg timestamp="20260430 18:30:30.456" level="TRACE">Arguments: [ 'verify_uart.Should Print Hello World.fail0.save' | ' ' | '_' ]</msg>
+<msg timestamp="20260430 18:30:30.456" level="TRACE">Return: 'verify_uart.Should_Print_Hello_World.fail0.save'</msg>
+<msg timestamp="20260430 18:30:30.456" level="INFO">${test_name} = verify_uart.Should_Print_Hello_World.fail0.save</msg>
+<status status="PASS" starttime="20260430 18:30:30.455" endtime="20260430 18:30:30.456"/>
+</kw>
+<kw name="Replace String Using Regexp" library="String">
+<var>${test_name}</var>
+<arg>${test_name}</arg>
+<arg>[/""]</arg>
+<arg>-</arg>
+<doc>Replaces ``pattern`` in the given ``string`` with ``replace_with``.</doc>
+<msg timestamp="20260430 18:30:30.456" level="TRACE">Arguments: [ 'verify_uart.Should_Print_Hello_World.fail0.save' | '[/""]' | '-' ]</msg>
+<msg timestamp="20260430 18:30:30.456" level="TRACE">Return: 'verify_uart.Should_Print_Hello_World.fail0.save'</msg>
+<msg timestamp="20260430 18:30:30.456" level="INFO">${test_name} = verify_uart.Should_Print_Hello_World.fail0.save</msg>
+<status status="PASS" starttime="20260430 18:30:30.456" endtime="20260430 18:30:30.456"/>
+</kw>
+<return>
+<value>${test_name}</value>
+<status status="PASS" starttime="20260430 18:30:30.456" endtime="20260430 18:30:30.456"/>
+</return>
+<msg timestamp="20260430 18:30:30.457" level="TRACE">Return: 'verify_uart.Should_Print_Hello_World.fail0.save'</msg>
+<msg timestamp="20260430 18:30:30.457" level="INFO">${test_name} = verify_uart.Should_Print_Hello_World.fail0.save</msg>
+<status status="PASS" starttime="20260430 18:30:30.455" endtime="20260430 18:30:30.457"/>
+</kw>
+<kw name="Set Variable" library="BuiltIn">
+<var>${snapshots_dir}</var>
+<arg>${RESULTS_DIRECTORY}/snapshots</arg>
+<doc>Returns the given values which can then be assigned to a variables.</doc>
+<msg timestamp="20260430 18:30:30.457" level="TRACE">Arguments: [ '/app//snapshots' ]</msg>
+<msg timestamp="20260430 18:30:30.457" level="TRACE">Return: '/app//snapshots'</msg>
+<msg timestamp="20260430 18:30:30.457" level="INFO">${snapshots_dir} = /app//snapshots</msg>
+<status status="PASS" starttime="20260430 18:30:30.457" endtime="20260430 18:30:30.457"/>
+</kw>
+<kw name="Create Directory" library="OperatingSystem">
+<arg>${snapshots_dir}</arg>
+<doc>Creates the specified directory.</doc>
+<msg timestamp="20260430 18:30:30.457" level="TRACE">Arguments: [ '/app//snapshots' ]</msg>
+<msg timestamp="20260430 18:30:30.458" level="INFO" html="true">Directory '&lt;a href="file:///app/snapshots"&gt;/app/snapshots&lt;/a&gt;' already exists.</msg>
+<msg timestamp="20260430 18:30:30.458" level="TRACE">Return: None</msg>
+<status status="PASS" starttime="20260430 18:30:30.457" endtime="20260430 18:30:30.458"/>
+</kw>
+<kw name="Set Variable" library="BuiltIn">
+<var>${snapshot_path}</var>
+<arg>"${snapshots_dir}/${test_name}"</arg>
+<doc>Returns the given values which can then be assigned to a variables.</doc>
+<msg timestamp="20260430 18:30:30.458" level="TRACE">Arguments: [ '"/app//snapshots/verify_uart.Should_Print_Hello_World.fail0.save"' ]</msg>
+<msg timestamp="20260430 18:30:30.458" level="TRACE">Return: '"/app//snapshots/verify_uart.Should_Print_Hello_World.fail0.save"'</msg>
+<msg timestamp="20260430 18:30:30.458" level="INFO">${snapshot_path} = "/app//snapshots/verify_uart.Should_Print_Hello_World.fail0.save"</msg>
+<status status="PASS" starttime="20260430 18:30:30.458" endtime="20260430 18:30:30.458"/>
+</kw>
+<kw name="Execute Command" library="Remote">
+<arg>Save ${snapshot_path}</arg>
+<msg timestamp="20260430 18:30:30.458" level="TRACE">Arguments: [ 'Save "/app//snapshots/verify_uart.Should_Print_Hello_World.fail0.save"' ]</msg>
+<msg timestamp="20260430 18:30:32.560" level="TRACE">Return: ''</msg>
+<status status="PASS" starttime="20260430 18:30:30.458" endtime="20260430 18:30:32.560"/>
+</kw>
+<kw name="Log To Console" library="BuiltIn">
+<arg>!!!!! Emulation's state saved to ${snapshot_path}</arg>
+<doc>Logs the given message to the console.</doc>
+<msg timestamp="20260430 18:30:32.561" level="TRACE">Arguments: [ '!!!!! Emulation\'s state saved to "/app//snapshots/verify_uart.Should_Print_Hello_World.fail0.save"' ]</msg>
+<msg timestamp="20260430 18:30:32.561" level="TRACE">Return: None</msg>
+<status status="PASS" starttime="20260430 18:30:32.560" endtime="20260430 18:30:32.561"/>
+</kw>
+<msg timestamp="20260430 18:30:32.561" level="TRACE">Return: None</msg>
+<status status="PASS" starttime="20260430 18:30:30.452" endtime="20260430 18:30:32.561"/>
+</kw>
+<msg timestamp="20260430 18:30:32.561" level="TRACE">Return: None</msg>
+<status status="PASS" starttime="20260430 18:30:30.452" endtime="20260430 18:30:32.561"/>
+</kw>
+<status status="PASS" starttime="20260430 18:30:30.452" endtime="20260430 18:30:32.561"/>
+</branch>
+<status status="PASS" starttime="20260430 18:30:30.452" endtime="20260430 18:30:32.561"/>
+</if>
+<if>
+<branch type="IF" condition="${SAVE_LOGS}">
+<if>
+<branch type="IF" condition="&quot;${SAVE_LOGS_WHEN}&quot; == &quot;Always&quot;">
+<kw name="Save Test Log" library="renode-keywords">
+<status status="NOT RUN" starttime="20260430 18:30:32.562" endtime="20260430 18:30:32.562"/>
+</kw>
+<status status="NOT RUN" starttime="20260430 18:30:32.562" endtime="20260430 18:30:32.562"/>
+</branch>
+<branch type="ELSE IF" condition="&quot;${SAVE_LOGS_WHEN}&quot; == &quot;Fail&quot;">
+<kw name="Run Keyword If Test Failed" library="BuiltIn">
+<arg>Save Test Log</arg>
+<doc>Runs the given keyword with the given arguments, if the test failed.</doc>
+<msg timestamp="20260430 18:30:32.562" level="TRACE">Arguments: [ 'Save Test Log' ]</msg>
+<kw name="Save Test Log" library="renode-keywords">
+<msg timestamp="20260430 18:30:32.563" level="TRACE">Arguments: [  ]</msg>
+<kw name="Return From Keyword If" library="BuiltIn">
+<arg>'skipped' in @{TEST TAGS}</arg>
+<doc>Returns from the enclosing user keyword if ``condition`` is true.</doc>
+<msg timestamp="20260430 18:30:32.563" level="TRACE">Arguments: [ "'skipped' in []" ]</msg>
+<msg timestamp="20260430 18:30:32.563" level="TRACE">Return: None</msg>
+<status status="PASS" starttime="20260430 18:30:32.563" endtime="20260430 18:30:32.563"/>
+</kw>
+<kw name="Get Variable Value" library="BuiltIn">
+<var>${retry_index}</var>
+<arg>\${RETRYFAILED_RETRY_INDEX}</arg>
+<arg>0</arg>
+<doc>Returns variable value or ``default`` if the variable does not exist.</doc>
+<msg timestamp="20260430 18:30:32.563" level="TRACE">Arguments: [ '\\${RETRYFAILED_RETRY_INDEX}' | '0' ]</msg>
+<msg timestamp="20260430 18:30:32.564" level="TRACE">Return: '0'</msg>
+<msg timestamp="20260430 18:30:32.564" level="INFO">${retry_index} = 0</msg>
+<status status="PASS" starttime="20260430 18:30:32.563" endtime="20260430 18:30:32.565"/>
+</kw>
+<kw name="Set Variable" library="BuiltIn">
+<var>${test_name}</var>
+<arg>${SUITE NAME}.${TEST NAME}.fail${retry_index}</arg>
+<doc>Returns the given values which can then be assigned to a variables.</doc>
+<msg timestamp="20260430 18:30:32.565" level="TRACE">Arguments: [ 'verify_uart.Should Print Hello World.fail0' ]</msg>
+<msg timestamp="20260430 18:30:32.565" level="TRACE">Return: 'verify_uart.Should Print Hello World.fail0'</msg>
+<msg timestamp="20260430 18:30:32.565" level="INFO">${test_name} = verify_uart.Should Print Hello World.fail0</msg>
+<status status="PASS" starttime="20260430 18:30:32.565" endtime="20260430 18:30:32.565"/>
+</kw>
+<kw name="Sanitize Test Name" library="renode-keywords">
+<var>${test_name}</var>
+<arg>${test_name}</arg>
+<msg timestamp="20260430 18:30:32.566" level="TRACE">Arguments: [ ${test_name}='verify_uart.Should Print Hello World.fail0' ]</msg>
+<kw name="Replace String" library="String">
+<var>${test_name}</var>
+<arg>${test_name}</arg>
+<arg>${SPACE}</arg>
+<arg>_</arg>
+<doc>Replaces ``search_for`` in the given ``string`` with ``replace_with``.</doc>
+<msg timestamp="20260430 18:30:32.566" level="TRACE">Arguments: [ 'verify_uart.Should Print Hello World.fail0' | ' ' | '_' ]</msg>
+<msg timestamp="20260430 18:30:32.566" level="TRACE">Return: 'verify_uart.Should_Print_Hello_World.fail0'</msg>
+<msg timestamp="20260430 18:30:32.566" level="INFO">${test_name} = verify_uart.Should_Print_Hello_World.fail0</msg>
+<status status="PASS" starttime="20260430 18:30:32.566" endtime="20260430 18:30:32.566"/>
+</kw>
+<kw name="Replace String Using Regexp" library="String">
+<var>${test_name}</var>
+<arg>${test_name}</arg>
+<arg>[/""]</arg>
+<arg>-</arg>
+<doc>Replaces ``pattern`` in the given ``string`` with ``replace_with``.</doc>
+<msg timestamp="20260430 18:30:32.567" level="TRACE">Arguments: [ 'verify_uart.Should_Print_Hello_World.fail0' | '[/""]' | '-' ]</msg>
+<msg timestamp="20260430 18:30:32.567" level="TRACE">Return: 'verify_uart.Should_Print_Hello_World.fail0'</msg>
+<msg timestamp="20260430 18:30:32.567" level="INFO">${test_name} = verify_uart.Should_Print_Hello_World.fail0</msg>
+<status status="PASS" starttime="20260430 18:30:32.566" endtime="20260430 18:30:32.567"/>
+</kw>
+<return>
+<value>${test_name}</value>
+<status status="PASS" starttime="20260430 18:30:32.567" endtime="20260430 18:30:32.567"/>
+</return>
+<msg timestamp="20260430 18:30:32.567" level="TRACE">Return: 'verify_uart.Should_Print_Hello_World.fail0'</msg>
+<msg timestamp="20260430 18:30:32.567" level="INFO">${test_name} = verify_uart.Should_Print_Hello_World.fail0</msg>
+<status status="PASS" starttime="20260430 18:30:32.565" endtime="20260430 18:30:32.567"/>
+</kw>
+<kw name="Set Variable" library="BuiltIn">
+<var>${logs_dir}</var>
+<arg>${RESULTS_DIRECTORY}/logs</arg>
+<doc>Returns the given values which can then be assigned to a variables.</doc>
+<msg timestamp="20260430 18:30:32.567" level="TRACE">Arguments: [ '/app//logs' ]</msg>
+<msg timestamp="20260430 18:30:32.567" level="TRACE">Return: '/app//logs'</msg>
+<msg timestamp="20260430 18:30:32.567" level="INFO">${logs_dir} = /app//logs</msg>
+<status status="PASS" starttime="20260430 18:30:32.567" endtime="20260430 18:30:32.568"/>
+</kw>
+<kw name="Create Directory" library="OperatingSystem">
+<arg>${logs_dir}</arg>
+<doc>Creates the specified directory.</doc>
+<msg timestamp="20260430 18:30:32.568" level="TRACE">Arguments: [ '/app//logs' ]</msg>
+<msg timestamp="20260430 18:30:32.568" level="INFO" html="true">Directory '&lt;a href="file:///app/logs"&gt;/app/logs&lt;/a&gt;' already exists.</msg>
+<msg timestamp="20260430 18:30:32.568" level="TRACE">Return: None</msg>
+<status status="PASS" starttime="20260430 18:30:32.568" endtime="20260430 18:30:32.568"/>
+</kw>
+<kw name="Set Variable" library="BuiltIn">
+<var>${log_path}</var>
+<arg>${logs_dir}/${test_name}.log</arg>
+<doc>Returns the given values which can then be assigned to a variables.</doc>
+<msg timestamp="20260430 18:30:32.568" level="TRACE">Arguments: [ '/app//logs/verify_uart.Should_Print_Hello_World.fail0.log' ]</msg>
+<msg timestamp="20260430 18:30:32.568" level="TRACE">Return: '/app//logs/verify_uart.Should_Print_Hello_World.fail0.log'</msg>
+<msg timestamp="20260430 18:30:32.568" level="INFO">${log_path} = /app//logs/verify_uart.Should_Print_Hello_World.fail0.log</msg>
+<status status="PASS" starttime="20260430 18:30:32.568" endtime="20260430 18:30:32.568"/>
+</kw>
+<kw name="Log To Console" library="BuiltIn">
+<arg>!!!!! Log saved to "${log_path}"</arg>
+<doc>Logs the given message to the console.</doc>
+<msg timestamp="20260430 18:30:32.569" level="TRACE">Arguments: [ '!!!!! Log saved to "/app//logs/verify_uart.Should_Print_Hello_World.fail0.log"' ]</msg>
+<msg timestamp="20260430 18:30:32.569" level="TRACE">Return: None</msg>
+<status status="PASS" starttime="20260430 18:30:32.569" endtime="20260430 18:30:32.569"/>
+</kw>
+<kw name="Save Cached Log" library="Remote">
+<arg>${log_path}</arg>
+<msg timestamp="20260430 18:30:32.569" level="TRACE">Arguments: [ '/app//logs/verify_uart.Should_Print_Hello_World.fail0.log' ]</msg>
+<msg timestamp="20260430 18:30:32.579" level="TRACE">Return: ''</msg>
+<status status="PASS" starttime="20260430 18:30:32.569" endtime="20260430 18:30:32.579"/>
+</kw>
+<msg timestamp="20260430 18:30:32.579" level="TRACE">Return: None</msg>
+<status status="PASS" starttime="20260430 18:30:32.562" endtime="20260430 18:30:32.579"/>
+</kw>
+<msg timestamp="20260430 18:30:32.579" level="TRACE">Return: None</msg>
+<status status="PASS" starttime="20260430 18:30:32.562" endtime="20260430 18:30:32.579"/>
+</kw>
+<status status="PASS" starttime="20260430 18:30:32.562" endtime="20260430 18:30:32.579"/>
+</branch>
+<status status="PASS" starttime="20260430 18:30:32.561" endtime="20260430 18:30:32.579"/>
+</if>
+<status status="PASS" starttime="20260430 18:30:32.561" endtime="20260430 18:30:32.579"/>
+</branch>
+<status status="PASS" starttime="20260430 18:30:32.561" endtime="20260430 18:30:32.580"/>
+</if>
+<if>
+<branch type="IF" condition="${HOLD_ON_ERROR}">
+<kw name="Run Keyword If Test Failed" library="BuiltIn">
+<var>${res}</var>
+<arg>Run Keyword And Ignore Error</arg>
+<arg>Import Library</arg>
+<arg>Dialogs</arg>
+<doc>Runs the given keyword with the given arguments, if the test failed.</doc>
+<status status="NOT RUN" starttime="20260430 18:30:32.580" endtime="20260430 18:30:32.580"/>
+</kw>
+<kw name="Run Keyword If Test Failed" library="BuiltIn">
+<arg>Run Keywords</arg>
+<arg>Run Keyword If</arg>
+<arg>'${res[0]}' == 'FAIL'</arg>
+<arg>Log</arg>
+<arg>Couldn't load the Dialogs library - interactive debugging is not possible</arg>
+<arg>console=True</arg>
+<arg>AND</arg>
+<arg>Run Keyword If</arg>
+<arg>'${res[0]}' != 'FAIL'</arg>
+<arg>Open GUI</arg>
+<arg>AND</arg>
+<arg>Run Keyword If</arg>
+<arg>'${res[0]}' != 'FAIL'</arg>
+<arg>Pause Execution</arg>
+<arg>Test failed. Press OK once done debugging.</arg>
+<arg>AND</arg>
+<arg>Run Keyword If</arg>
+<arg>'${res[0]}' != 'FAIL'</arg>
+<arg>Close GUI</arg>
+<doc>Runs the given keyword with the given arguments, if the test failed.</doc>
+<status status="NOT RUN" starttime="20260430 18:30:32.580" endtime="20260430 18:30:32.580"/>
+</kw>
+<status status="NOT RUN" starttime="20260430 18:30:32.580" endtime="20260430 18:30:32.580"/>
+</branch>
+<status status="PASS" starttime="20260430 18:30:32.580" endtime="20260430 18:30:32.580"/>
+</if>
+<kw name="Reset Emulation" library="Remote">
+<msg timestamp="20260430 18:30:32.581" level="TRACE">Arguments: [  ]</msg>
+<msg timestamp="20260430 18:30:32.810" level="TRACE">Return: ''</msg>
+<status status="PASS" starttime="20260430 18:30:32.580" endtime="20260430 18:30:32.811"/>
+</kw>
+<kw name="Clear Cached Log" library="Remote">
+<msg timestamp="20260430 18:30:32.811" level="TRACE">Arguments: [  ]</msg>
+<msg timestamp="20260430 18:30:32.828" level="TRACE">Return: ''</msg>
+<status status="PASS" starttime="20260430 18:30:32.811" endtime="20260430 18:30:32.828"/>
+</kw>
+<msg timestamp="20260430 18:30:32.829" level="TRACE">Return: None</msg>
+<status status="PASS" starttime="20260430 18:30:30.447" endtime="20260430 18:30:32.829"/>
+</kw>
+<status status="FAIL" starttime="20260430 18:29:00.327" endtime="20260430 18:30:32.829">InvalidOperationException: Terminal tester failed!
+
+Full report:
+([host: 04/30/2026 18:29:26, virt:       0] Attached to UART event: success)
+ [[no newline]]
+([host: 04/30/2026 18:30:30, virt:    8000] Line containing &gt;&gt;Hello from XIAO RP2040!&lt;&lt; event: failure)</status>
+</test>
+<kw name="Teardown" library="renode-keywords" type="TEARDOWN">
+<msg timestamp="20260430 18:30:32.830" level="TRACE">Arguments: [  ]</msg>
+<if>
+<branch type="IF" condition="not ${SKIP_RUNNING_SERVER}">
+<kw name="Stop Remote Server" library="Remote">
+<status status="NOT RUN" starttime="20260430 18:30:32.830" endtime="20260430 18:30:32.830"/>
+</kw>
+<status status="NOT RUN" starttime="20260430 18:30:32.830" endtime="20260430 18:30:32.830"/>
+</branch>
+<status status="PASS" starttime="20260430 18:30:32.830" endtime="20260430 18:30:32.830"/>
+</if>
+<if>
+<branch type="IF" condition="not ${SKIP_RUNNING_SERVER}">
+<kw name="Wait For Process" library="Process">
+<doc>Waits for the process to complete or to reach the given timeout.</doc>
+<status status="NOT RUN" starttime="20260430 18:30:32.831" endtime="20260430 18:30:32.831"/>
+</kw>
+<status status="NOT RUN" starttime="20260430 18:30:32.831" endtime="20260430 18:30:32.831"/>
+</branch>
+<status status="PASS" starttime="20260430 18:30:32.830" endtime="20260430 18:30:32.831"/>
+</if>
+<msg timestamp="20260430 18:30:32.831" level="TRACE">Return: None</msg>
+<status status="PASS" starttime="20260430 18:30:32.830" endtime="20260430 18:30:32.831"/>
 </kw>
 <meta name="HotSpot_Action">-</meta>
-<status status="FAIL" starttime="20260430 13:30:24.925" endtime="20260430 13:30:25.007">Suite setup failed:
-Keyword 'renode-keywords.Setup Renode' expected 0 arguments, got 1.
-
-Also suite teardown failed:
-No keyword with name 'Teardown Renode' found. Did you try using keyword 'Teardown' or 'renode-keywords.Teardown' and forgot to use enough whitespace between keyword and arguments?</status>
+<status status="FAIL" starttime="20260430 18:28:59.476" endtime="20260430 18:30:32.831"/>
 </suite>
 <statistics>
 <total>

--- a/test/renode-config/cores/initialize_peripherals.resc
+++ b/test/renode-config/cores/initialize_peripherals.resc
@@ -1,5 +1,5 @@
-mach create $machine_name
+# mach create $machine_name
 
 # Load peripherals from the precompiled DLL. For live source compilation during
 # development, include initialize_peripherals_source.resc instead.
-include $ORIGIN/load_peripherals.py
+include $ORIGIN/initialize_peripherals_source.resc

--- a/test/renode-config/run_xiao.resc
+++ b/test/renode-config/run_xiao.resc
@@ -1,12 +1,9 @@
 $machine_name?="seeed_xiao_rp2040"
 $platform_file?=$ORIGIN/boards/seeed_xiao_rp2040.repl
-include $ORIGIN/boards/initialize_custom_board.resc
+$board_initialization_file=$ORIGIN/boards/initialize_custom_board.resc
+include $ORIGIN/tests/prepare.resc
 
-sysbus LoadELF $global.FIRMWARE
-
-# The bootrom is already loaded by initialize_custom_board.resc
-# We just need to make sure the vector table is correct if needed,
-# but LoadELF usually handles the entry point.
+# Arduino firmware entry point
+sysbus.cpu0 PC 0x100030d5
 
 showAnalyzer sysbus.uart0
-start

--- a/test/verify_uart.robot
+++ b/test/verify_uart.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Suite Setup                   Setup
 Suite Teardown                Teardown
-Resource                      ${CURDIR}/renode-config/tests/common.resource
+Test Teardown                 Test Teardown
 
 *** Variables ***
 ${UART}                       sysbus.uart0
@@ -15,13 +15,7 @@ Should Print Hello World
     Wait For Line On Uart     Hello from XIAO RP2040!
 
 *** Keywords ***
-Setup
-    ${RENODE_PATH}=           Set Variable    ${CURDIR}/renode/renode
-    Setup Renode              ${RENODE_PATH}
-
-Teardown
-    Teardown Renode
-
 Create Machine
-    Execute Command           $global.FIRMWARE = @${FIRMWARE}
+    Execute Command           $global.TEST_FILE = @${FIRMWARE}
     Execute Command           include @${RESC}
+    Create Terminal Tester    ${UART}


### PR DESCRIPTION
I have fixed the infrastructure for running Renode tests by correcting the Robot Framework keywords and switching to source-based peripheral loading. I also updated the board configuration scripts to be more robust. Although the UART test is still failing to see the expected output, the environment is now correctly configured to run and debug the simulation.

Fixes #19

---
*PR created automatically by Jules for task [12127299168427111254](https://jules.google.com/task/12127299168427111254) started by @chatelao*