### PR TITLE
Implement Bidirectional UART Support and Tests

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,8 +24,8 @@ The final plan to implement the `CONCEPT.md` and `DESIGN.md` to achieve the top 
 ## Phase 4: Peripheral Implementation
 ### UART Support
 - [x] Verify basic UART output in Renode [2026-04-30]
-- [ ] Implement UART input handling in simulation
-- [ ] Add Robot Framework tests for UART bidirectional communication
+- [x] Implement UART input handling in simulation [2026-04-30]
+- [x] Add Robot Framework tests for UART bidirectional communication [2026-04-30]
 
 ### ADC Support
 - [ ] Configure ADC in PlatformIO (Arduino/Pico SDK)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,22 +8,28 @@
 // NOTE: LEDs on XIAO RP2040 are active-low.
 
 const int LED_PIN = 17; // RED LED
+bool ledState = false;
 
 void setup() {
   // Use Serial1 for hardware UART output (mapped to sysbus.uart0 in Renode)
   Serial1.begin(115200);
   pinMode(LED_PIN, OUTPUT);
+  digitalWrite(LED_PIN, HIGH); // Start with LED OFF
+  Serial1.println("UART Bidirectional Communication Ready");
 }
 
 void loop() {
-  static bool state = false;
-  state = !state;
+  if (Serial1.available() > 0) {
+    char incomingByte = Serial1.read();
+    ledState = !ledState;
+    digitalWrite(LED_PIN, ledState ? LOW : HIGH);
+    Serial1.print("Echo: ");
+    Serial1.println(incomingByte);
+  }
 
-  // Active-low: LOW = ON, HIGH = OFF
-  digitalWrite(LED_PIN, state ? LOW : HIGH);
-
-  Serial1.print("Hello from XIAO RP2040! LED is ");
-  Serial1.println(state ? "ON" : "OFF");
-
-  delay(1000);
+  static unsigned long lastMsg = 0;
+  if (millis() - lastMsg > 1000) {
+    Serial1.println("Hello from XIAO RP2040!");
+    lastMsg = millis();
+  }
 }

--- a/test/test_uart_bidirectional.robot
+++ b/test/test_uart_bidirectional.robot
@@ -1,0 +1,27 @@
+*** Settings ***
+Suite Setup                   Setup
+Suite Teardown                Teardown
+Test Teardown                 Test Teardown
+
+*** Variables ***
+${UART}                       sysbus.uart0
+${FIRMWARE}                   ${CURDIR}/../.pio/build/seeed-xiao-rp2040/firmware.elf
+${RESC}                       ${CURDIR}/renode-config/run_xiao.resc
+
+*** Test Cases ***
+Should Echo UART Input
+    Create Machine
+    Start Emulation
+    Wait For Line On Uart     UART Bidirectional Communication Ready
+
+    Write Char On Uart        X
+    Wait For Line On Uart     Echo: X
+
+    Write Char On Uart        Y
+    Wait For Line On Uart     Echo: Y
+
+*** Keywords ***
+Create Machine
+    Execute Command           $global.TEST_FILE = @${FIRMWARE}
+    Execute Command           include @${RESC}
+    Create Terminal Tester    ${UART}


### PR DESCRIPTION
This change implements UART input handling in the firmware and adds a corresponding Robot Framework test to verify bidirectional communication in Renode. The firmware now echoes received characters and toggles the RED LED upon reception. The main loop was updated to be non-blocking using millis().

Fixes #23

---
*PR created automatically by Jules for task [13029522477797596518](https://jules.google.com/task/13029522477797596518) started by @chatelao*