### PR TITLE
Implement basic PWM support and update roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,7 +33,8 @@ The final plan to implement the `CONCEPT.md` and `DESIGN.md` to achieve the top 
 - [x] Create Robot Framework test for ADC reading with simulated analog values [2026-05-01]
 
 ### PWM Support
-- [ ] Configure PWM in PlatformIO
+- [x] Configure PWM in PlatformIO [2026-05-22]
+- [ ] Implement PWM peripheral model in Renode (missing in current config)
 - [ ] Map PWM pins in Renode `.repl` file
 - [ ] Create Robot Framework test for PWM frequency and duty cycle verification
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,12 @@ void loop() {
       int adcValue = analogRead(A0);
       Serial1.print("ADC0: ");
       Serial1.println(adcValue);
+    } else if (incomingByte == 'P') {
+      static int pwmValue = 0;
+      pwmValue = (pwmValue + 64) % 256;
+      analogWrite(LED_PIN, pwmValue);
+      Serial1.print("PWM set to: ");
+      Serial1.println(pwmValue);
     } else {
       Serial1.print("Echo: ");
       Serial1.println(incomingByte);


### PR DESCRIPTION
This change implements a 'P' command in the UART handler to control the RED LED using PWM via 'analogWrite'. It also updates the ROADMAP.md to reflect this progress and identifies the next step: implementing the PWM peripheral model in Renode.

Fixes #29

---
*PR created automatically by Jules for task [1359216982857146562](https://jules.google.com/task/1359216982857146562) started by @chatelao*