### PR TITLE
Implement basic RP2040 PWM peripheral in Renode

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,7 +34,8 @@ The final plan to implement the `CONCEPT.md` and `DESIGN.md` to achieve the top 
 
 ### PWM Support
 - [x] Configure PWM in PlatformIO [2026-05-22]
-- [ ] Implement PWM peripheral model in Renode (missing in current config)
+- [x] Implement basic PWM peripheral model in Renode (register stub) [2026-05-01]
+- [x] Implement PWM slice register handling (CSR, DIV, CTR, TOP, CC) [2026-05-01]
 - [ ] Map PWM pins in Renode `.repl` file
 - [ ] Create Robot Framework test for PWM frequency and duty cycle verification
 

--- a/test/renode-config/cores/initialize_peripherals_source.resc
+++ b/test/renode-config/cores/initialize_peripherals_source.resc
@@ -45,6 +45,8 @@ include $ORIGIN/../emulation/peripherals/sio/rp2040_sio.cs
 
 include $ORIGIN/../emulation/peripherals/adc/rp2040_adc.cs
 
+include $ORIGIN/../emulation/peripherals/pwm/rp2040_pwm.cs
+
 include $ORIGIN/../emulation/peripherals/uart/rp2040_uart.cs
 
 include $ORIGIN/../emulation/peripherals/dma/rpdma_engine.cs

--- a/test/renode-config/cores/rp2040.repl
+++ b/test/renode-config/cores/rp2040.repl
@@ -226,3 +226,7 @@ i2c1:
 psm: Miscellaneous.PSM @ sysbus 0x40010000 {
     address: 0x40010000
 }
+
+pwm: PWM.RP2040PWM @ sysbus 0x40050000 {
+    address: 0x40050000
+}

--- a/test/renode-config/emulation/peripherals/pwm/rp2040_pwm.cs
+++ b/test/renode-config/emulation/peripherals/pwm/rp2040_pwm.cs
@@ -1,0 +1,145 @@
+/**
+ * rp2040_pwm.cs
+ *
+ * Copyright (c) 2024 Jules
+ *
+ * Distributed under the terms of the MIT License.
+ */
+
+using System;
+using System.Collections.Generic;
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Core.Structure.Registers;
+using Antmicro.Renode.Logging;
+using Antmicro.Renode.Peripherals.Bus;
+using Antmicro.Renode.Utilities;
+
+namespace Antmicro.Renode.Peripherals.PWM
+{
+    public class RP2040PWM : RP2040PeripheralBase
+    {
+        public RP2040PWM(IMachine machine, ulong address) : base(machine, address)
+        {
+            slices = new PWMSlice[NumberOfSlices];
+            for (int i = 0; i < NumberOfSlices; ++i)
+            {
+                slices[i] = new PWMSlice(this, i);
+            }
+            DefineRegisters();
+        }
+
+        private void DefineRegisters()
+        {
+            Registers.CH0_CSR.DefineMany(this, NumberOfSlices, (reg, index) =>
+            {
+                reg.WithFlag(0, out slices[index].enabled, name: $"CH{index}_CSR_EN")
+                   .WithValueField(1, 2, out slices[index].divMode, name: $"CH{index}_CSR_DIVMODE")
+                   .WithFlag(3, out slices[index].phaseCorrect, name: $"CH{index}_CSR_PH_CORRECT")
+                   .WithFlag(4, out slices[index].invertA, name: $"CH{index}_CSR_A_INV")
+                   .WithFlag(5, out slices[index].invertB, name: $"CH{index}_CSR_B_INV")
+                   .WithValueField(6, 1, name: $"CH{index}_CSR_TOP_SEL")
+                   .WithFlag(7, name: $"CH{index}_CSR_ADVANCE")
+                   .WithReservedBits(8, 24);
+            }, stepInBytes: 0x14);
+
+            Registers.CH0_DIV.DefineMany(this, NumberOfSlices, (reg, index) =>
+            {
+                reg.WithValueField(0, 8, out slices[index].divFrac, name: $"CH{index}_DIV_FRAC")
+                   .WithValueField(8, 8, out slices[index].divInt, name: $"CH{index}_DIV_INT")
+                   .WithReservedBits(16, 16);
+            }, stepInBytes: 0x14);
+
+            Registers.CH0_CTR.DefineMany(this, NumberOfSlices, (reg, index) =>
+            {
+                reg.WithValueField(0, 16, out slices[index].counter, name: $"CH{index}_CTR")
+                   .WithReservedBits(16, 16);
+            }, stepInBytes: 0x14);
+
+            Registers.CH0_CC.DefineMany(this, NumberOfSlices, (reg, index) =>
+            {
+                reg.WithValueField(0, 16, out slices[index].compareA, name: $"CH{index}_CC_A")
+                   .WithValueField(16, 16, out slices[index].compareB, name: $"CH{index}_CC_B");
+            }, stepInBytes: 0x14);
+
+            Registers.CH0_TOP.DefineMany(this, NumberOfSlices, (reg, index) =>
+            {
+                reg.WithValueField(0, 16, out slices[index].top, name: $"CH{index}_TOP")
+                   .WithReservedBits(16, 16);
+            }, stepInBytes: 0x14);
+
+            Registers.EN.Define(this)
+                .WithValueField(0, 8, writeCallback: (_, val) =>
+                {
+                    for (int i = 0; i < 8; i++)
+                    {
+                        slices[i].enabled.Value = BitHelper.IsBitSet(val, (byte)i);
+                    }
+                }, valueProviderCallback: _ =>
+                {
+                    uint val = 0;
+                    for (int i = 0; i < 8; i++)
+                    {
+                        if (slices[i].enabled.Value) val |= (1u << i);
+                    }
+                    return val;
+                }, name: "EN");
+
+            Registers.INTR.Define(this)
+                .WithValueField(0, 8, name: "INTR");
+            Registers.INTE.Define(this)
+                .WithValueField(0, 8, name: "INTE");
+            Registers.INTF.Define(this)
+                .WithValueField(0, 8, name: "INTF");
+            Registers.INTS.Define(this)
+                .WithValueField(0, 8, name: "INTS");
+        }
+
+        public override void Reset()
+        {
+            base.Reset();
+            // All slices should be reset by the base call if their fields are part of RegistersCollection
+        }
+
+        private readonly PWMSlice[] slices;
+        private const int NumberOfSlices = 8;
+
+        private class PWMSlice
+        {
+            public PWMSlice(RP2040PWM parent, int index)
+            {
+                this.parent = parent;
+                this.index = index;
+            }
+
+            public IFlagRegisterField enabled;
+            public IValueRegisterField divMode;
+            public IFlagRegisterField phaseCorrect;
+            public IFlagRegisterField invertA;
+            public IFlagRegisterField invertB;
+            public IValueRegisterField divFrac;
+            public IValueRegisterField divInt;
+            public IValueRegisterField counter;
+            public IValueRegisterField compareA;
+            public IValueRegisterField compareB;
+            public IValueRegisterField top;
+
+            private readonly RP2040PWM parent;
+            private readonly int index;
+        }
+
+        private enum Registers
+        {
+            CH0_CSR = 0x00,
+            CH0_DIV = 0x04,
+            CH0_CTR = 0x08,
+            CH0_CC = 0x0c,
+            CH0_TOP = 0x10,
+            // Slices 1-7 follow at 0x14 intervals
+            EN = 0xa0,
+            INTR = 0xa4,
+            INTE = 0xa8,
+            INTF = 0xac,
+            INTS = 0xb0
+        }
+    }
+}


### PR DESCRIPTION
Implemented a basic RP2040 PWM peripheral model in Renode to support the next step in the project roadmap. The implementation includes:
1. A new C# peripheral model (`rp2040_pwm.cs`) that handles the standard PWM registers for all 8 slices.
2. Integration of the PWM peripheral into the RP2040 platform description and initialization scripts.
3. Refined `ROADMAP.md` to track the granular steps of PWM support.
4. Successful verification that the firmware's PWM accesses no longer crash the simulation and are correctly handled by the new model.

Fixes #31

---
*PR created automatically by Jules for task [5035519143489424385](https://jules.google.com/task/5035519143489424385) started by @chatelao*