### PR TITLE
Update project goal and derived documents to include Interrupts and Timer

### DIFF
--- a/CONCEPT.md
+++ b/CONCEPT.md
@@ -3,7 +3,7 @@
 The overall structure of the product, including Business & Use Cases as well as the High-Level Architecture.
 
 ## Goal
-Create a setup for the XIAO Seeed RP2040 able to run the UART, the ADC and the PWM on Renode over PlatformIO.
+Create a setup for the XIAO Seeed RP2040 able to run the UART, the ADC, the PWM, the Interrupts and the Timer on Renode over PlatformIO.
 
 ## Business & Use Cases
 ### Business Cases
@@ -11,19 +11,21 @@ Create a setup for the XIAO Seeed RP2040 able to run the UART, the ADC and the P
 - **Continuous Integration:** Provide a simulated environment for automated testing of peripheral drivers and application logic in CI/CD pipelines.
 
 ### Use Cases
-- **Firmware Development:** A developer writes code for XIAO Seeed RP2040 peripherals (UART, ADC, PWM) and wants to verify the logic in a simulated environment.
+- **Firmware Development:** A developer writes code for XIAO Seeed RP2040 peripherals (UART, ADC, PWM, Interrupts, Timer) and wants to verify the logic in a simulated environment.
 - **Automated Regression Testing:** Every commit to the firmware repository triggers a build and a simulation run in Renode to ensure no regressions in peripheral handling.
 
 ## High-Level Architecture
 The system consists of three main components:
 1. **Development Environment (PlatformIO):** Handles firmware compilation, dependency management, and target configuration for the RP2040.
 2. **Simulation Engine (Renode):** Emulates the RP2040 SoC and board-level peripherals.
-3. **Glue/Configuration Layer:** Bridges PlatformIO build artifacts with Renode simulation scripts and provides the necessary peripheral models (UART, ADC, PWM).
+3. **Glue/Configuration Layer:** Bridges PlatformIO build artifacts with Renode simulation scripts and provides the necessary peripheral models (UART, ADC, PWM, Interrupts, Timer).
 
 ## Functional Components
 - **UART Interface:** For serial communication simulation and console output.
 - **ADC (Analog-to-Digital Converter):** For simulating sensor inputs and analog signal processing.
 - **PWM (Pulse Width Modulation):** For simulating motor control, LED dimming, or other timed outputs.
+- **Interrupts:** For handling asynchronous events and hardware signals.
+- **Timer:** For precise timing, delays, and periodic event execution.
 
 ## Major Choices & Alternatives
 ### Choice 1: Emulation Framework

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -14,13 +14,13 @@ The detailed design of the solution, including the architecture, used tech stack
 - **Option A: GitHub Actions (Selected)** - Integrated CI/CD platform for GitHub repositories, allowing for automated builds and simulation runs. Explicitly mentioned in the `ROADMAP.md`.
 
 ## Detailed Architecture
-- (To be defined)
+- (To be defined, including Interrupts and Timer)
 
 ## Technical Interfaces
-- (To be defined)
+- (To be defined, including Interrupts and Timer)
 
 ## Implementation Choices
-- (To be defined)
+- (To be defined, including Interrupts and Timer)
 
 ## Discarded Alternatives
 ### Choice 3: Programming SDK

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
 # Goal
-Create a setup for the XIAO Seeed RP2040 able to run the UART, the ADC and the PWM on Renode over PlatformIO.
+Create a setup for the XIAO Seeed RP2040 able to run the UART, the ADC, the PWM, the Interrupts and the Timer on Renode over PlatformIO.
 
 # Structure
 - `CONCEPT.md`: The overall structure of the product, including Business & Use Cases as well as the High-Level Architecture.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,8 +39,18 @@ The final plan to implement the `CONCEPT.md` and `DESIGN.md` to achieve the top 
 - [x] Map PWM pins in Renode `.repl` file [2026-05-22]
    - [x] Create Robot Framework test for PWM frequency and duty cycle verification [2026-05-22]
 
+### Interrupt Support
+- [ ] Configure NVIC and interrupt vectors in Renode
+- [ ] Implement basic interrupt handling in firmware
+- [ ] Create Robot Framework test for interrupt-driven events
+
+### Timer Support
+- [ ] Configure RP2040 Timer peripheral in Renode
+- [ ] Implement timer-based delays and alarms in firmware
+- [ ] Create Robot Framework test for timer accuracy and periodic interrupts
+
 ## Phase 5: Verification & Documentation
-- [ ] Finalize test cases for UART, ADC, and PWM
+- [ ] Finalize test cases for UART, ADC, PWM, Interrupts, and Timer
    - [x] Create a unified Robot Framework test suite `test/full_suite.robot` [2026-05-02]
    - [x] Verify the unified test suite passes [2026-05-02]
 - [ ] Run full CI/CD suite


### PR DESCRIPTION
This submission updates the project's documentation to reflect the expanded scope of including Interrupt and Timer support for the XIAO Seeed RP2040 simulation. The changes cover GEMINI.md, CONCEPT.md, DESIGN.md, and ROADMAP.md, ensuring consistency across all project-level specifications and planning documents. Current system stability was verified by executing the existing test suite after the documentation updates.

Fixes #45

---
*PR created automatically by Jules for task [5564676037892846199](https://jules.google.com/task/5564676037892846199) started by @chatelao*