### PR TITLE
Implement Interrupt Support for RP2040 and XIAO

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,9 +40,9 @@ The final plan to implement the `CONCEPT.md` and `DESIGN.md` to achieve the top 
    - [x] Create Robot Framework test for PWM frequency and duty cycle verification [2026-05-22]
 
 ### Interrupt Support
-- [ ] Configure NVIC and interrupt vectors in Renode
-- [ ] Implement basic interrupt handling in firmware
-- [ ] Create Robot Framework test for interrupt-driven events
+- [x] Configure NVIC and interrupt vectors in Renode [2026-05-02]
+- [x] Implement basic interrupt handling in firmware [2026-05-02]
+- [x] Create Robot Framework test for interrupt-driven events [2026-05-02]
 
 ### Timer Support
 - [ ] Configure RP2040 Timer peripheral in Renode

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,13 +8,23 @@
 // NOTE: LEDs on XIAO RP2040 are active-low.
 
 const int LED_PIN = 17; // RED LED
+const int INTERRUPT_PIN = 2; // XIAO D8
 bool ledState = false;
+volatile bool interruptOccurred = false;
+
+void handleInterrupt() {
+  interruptOccurred = true;
+}
 
 void setup() {
   // Use Serial1 for hardware UART output (mapped to sysbus.uart0 in Renode)
   Serial1.begin(115200);
   pinMode(LED_PIN, OUTPUT);
   digitalWrite(LED_PIN, HIGH); // Start with LED OFF
+
+  // Configure Interrupt Pin
+  pinMode(INTERRUPT_PIN, INPUT_PULLUP);
+  attachInterrupt(digitalPinToInterrupt(INTERRUPT_PIN), handleInterrupt, RISING);
 
   // Configure ADC
   analogReadResolution(12);
@@ -23,6 +33,11 @@ void setup() {
 }
 
 void loop() {
+  if (interruptOccurred) {
+    interruptOccurred = false;
+    Serial1.println("GPIO Interrupt Handled");
+  }
+
   if (Serial1.available() > 0) {
     char incomingByte = Serial1.read();
     ledState = !ledState;

--- a/test/full_suite.robot
+++ b/test/full_suite.robot
@@ -75,6 +75,17 @@ Should Cycle PWM Duty Cycle
     Wait For Line On Uart     PWM set to: 0
     Verify Duty Cycle         0  B  0.0
 
+Should Handle GPIO Interrupt
+    Create Machine
+    Start Emulation
+
+    # Wait for the initial UART message
+    Wait For Line On Uart     UART Bidirectional Communication Ready
+
+    # Trigger GPIO interrupt on GPIO 2
+    Execute Command           sysbus.gpio OnGPIO 2 true
+    Wait For Line On Uart     GPIO Interrupt Handled
+
 *** Keywords ***
 Create Machine
     Execute Command           $global.TEST_FILE = @${FIRMWARE}

--- a/test/renode-config/cores/rp2040.repl
+++ b/test/renode-config/cores/rp2040.repl
@@ -190,6 +190,7 @@ adc: Analog.RP2040ADC @ sysbus 0x4004c000 {
     pads: pads
 }
 adc:
+    IRQ -> nvic0@22
     DMARequest -> dma@36
 
 gpio_qspi:

--- a/test/renode-config/emulation/peripherals/adc/rp2040_adc.cs
+++ b/test/renode-config/emulation/peripherals/adc/rp2040_adc.cs
@@ -28,6 +28,7 @@ namespace Antmicro.Renode.Peripherals.Analog
   {
     public RP2040ADC(IMachine machine, RP2040Clocks clocks, RP2040Pads pads, ulong address) : base(machine, address)
     {
+      this.IRQ = new GPIO();
       this.fifo = new CircularBuffer<ushort>(fifoSize);
       this.sampleProvider = new SensorSamplesFifo<ScalarSample>[channelsCount];
       this.resdStream = new RESDStream<VoltageSample>[channelsCount];
@@ -530,7 +531,7 @@ namespace Antmicro.Renode.Peripherals.Analog
       INTS = 0x20
     };
 
-    public GPIO IRQ;
+    public GPIO IRQ { get; private set; }
     public GPIO DMARequest { get; }
 
 


### PR DESCRIPTION
This PR implements the "Interrupt Support" step from Phase 4 of the roadmap.

Key changes:
1. **Renode Configuration**: Updated `test/renode-config/cores/rp2040.repl` to wire the ADC interrupt to NVIC index 22.
2. **Firmware**: Modified `src/main.cpp` to set up a rising-edge interrupt on GPIO 2 (mapping to XIAO D8). The ISR sets a flag, and the main loop reports "GPIO Interrupt Handled" over UART when triggered.
3. **Tests**: Expanded `test/full_suite.robot` with a new test case that simulates a GPIO interrupt in Renode using `sysbus.gpio OnGPIO 2 true` and verifies the corresponding UART output.
4. **Peripheral Model Fix**: Updated `test/renode-config/emulation/peripherals/adc/rp2040_adc.cs` to add a public `IRQ` property. This was necessary because the Renode loader requires an explicit property to bind interrupt connections defined in the `.repl` file.
5. **Roadmap**: Marked the Interrupt Support tasks as completed in `ROADMAP.md`.

All tests in the unified suite passed successfully.

Fixes #51

---
*PR created automatically by Jules for task [2919039277753640100](https://jules.google.com/task/2919039277753640100) started by @chatelao*