### PR TITLE
Document rationale for custom RP2040 UART implementation

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -20,7 +20,8 @@ The detailed design of the solution, including the architecture, used tech stack
 - (To be defined, including Interrupts and Timer)
 
 ## Implementation Choices
-- (To be defined, including Interrupts and Timer)
+- **UART Peripheral:** The project utilizes a custom `RP2040Uart` model (located at `test/renode-config/emulation/peripherals/uart/rp2040_uart.cs`) rather than the stock Renode `UART.PL011`. This choice is driven by the RP2040 hardware specification, which requires support for atomic register aliases (XOR, SET, CLEAR) and specific integration with the DMA and PIO subsystems. The custom model implements the `IRP2040Peripheral` interface to provide these atomic operations and ensures accurate simulation of inter-peripheral communication.
+- **Interrupts and Timer:** (To be defined)
 
 ## Discarded Alternatives
 ### Choice 3: Programming SDK


### PR DESCRIPTION
The user inquired about the existence of an exact PL011 module in Renode and why it wasn't being used directly.

Upon investigation, it was confirmed that while the RP2040 UART is based on the ARM PrimeCell UART (PL011), the RP2040 hardware implements a unique bus architecture where peripherals have atomic register aliases (XOR, SET, CLEAR) at specific offsets. The standard Renode `UART.PL011` model does not natively support these RP2040-specific operations.

This submission documents the design choice in `DESIGN.md`, explaining that the custom `RP2040Uart` peripheral (implementing the `IRP2040Peripheral` interface) is necessary to ensure compatibility with the RP2040 hardware specification and SDKs that utilize these atomic bus features.

Changes:
- Updated `DESIGN.md` under "Implementation Choices" with the UART rationale.
- Verified the implementation remains correct by running the full simulation test suite.

Fixes #54

---
*PR created automatically by Jules for task [16781193339857651885](https://jules.google.com/task/16781193339857651885) started by @chatelao*