### PR TITLE
Add ReadTheDocs tasks to roadmap

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -13,6 +13,9 @@ The detailed design of the solution, including the architecture, used tech stack
 ### Choice 5: CI/CD Platform
 - **Option A: GitHub Actions (Selected)** - Integrated CI/CD platform for GitHub repositories, allowing for automated builds and simulation runs. Explicitly mentioned in the `ROADMAP.md`.
 
+### Choice 6: Documentation Generator
+- **Option A: MkDocs (Selected)** - Fast and simple static site generator that's geared towards building project documentation. Documentation source files are written in Markdown, and configured with a single YAML configuration file.
+
 ## Detailed Architecture
 - (To be defined, including Interrupts and Timer)
 
@@ -35,3 +38,7 @@ The detailed design of the solution, including the architecture, used tech stack
 ### Choice 5: CI/CD Platform
 - **Option B: GitLab CI/CD** - Requires external hosting or mirroring for this repository.
 - **Option C: Local Bash Scripts** - Not suitable for automated, cloud-based continuous integration and reporting.
+
+### Choice 6: Documentation Generator
+- **Option B: Sphinx** - Powerful documentation tool that uses reStructuredText as its default markup language, but can also support Markdown. It is widely used in the Python community.
+- **Option C: Doxygen** - Standard tool for generating documentation from annotated C++ sources, but less focused on high-level conceptual and design documentation.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -57,7 +57,10 @@ The final plan to implement the `CONCEPT.md` and `DESIGN.md` to achieve the top 
 - [ ] Update documentation with final design and usage instructions
    - [ ] Create `USAGE.md` with instructions for building and testing
    - [ ] Finalize `CONCEPT.md` and `DESIGN.md`
-- [ ] Implement ReadTheDocs integration
-   - [ ] Create `.readthedocs.yaml` configuration
-   - [ ] Integrate ReadTheDocs with GitHub Actions
-   - [ ] Verify automatic documentation updates on ReadTheDocs
+## Phase 6: Continuous Documentation
+- [ ] Initialize MkDocs documentation structure
+- [ ] Create `mkdocs.yml` configuration
+- [ ] Create `docs/requirements.txt` for documentation dependencies
+- [ ] Create `.readthedocs.yaml` configuration
+- [ ] Integrate ReadTheDocs with GitHub Actions
+- [ ] Verify automatic documentation updates on ReadTheDocs


### PR DESCRIPTION
Added ReadTheDocs and MkDocs tasks to the roadmap to ensure proper documentation integration. This included updating the technical choices in DESIGN.md to select MkDocs and creating a new Phase 6 in ROADMAP.md with detailed subtasks for setting up the documentation structure, configuration, and CI/CD integration.

Fixes #60

---
*PR created automatically by Jules for task [10210316052574212642](https://jules.google.com/task/10210316052574212642) started by @chatelao*