### PR TITLE
Integrate ReadTheDocs and CI Documentation Build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,11 @@ jobs:
       run: |
         pio run
 
+    - name: Build Documentation
+      run: |
+        pip install -r docs/requirements.txt
+        mkdocs build
+
     - name: Run Full Test Suite
       run: |
         ./test/renode/renode-test test/full_suite.robot

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ output.xml
 robot_output.xml
 logs/
 snapshots/
+
+# Documentation Build
+site/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+mkdocs:
+  configuration: mkdocs.yml
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -61,6 +61,6 @@ The final plan to implement the `CONCEPT.md` and `DESIGN.md` to achieve the top 
 - [x] Initialize MkDocs documentation structure [2026-05-03]
 - [x] Create `mkdocs.yml` configuration [2026-05-03]
 - [x] Create `docs/requirements.txt` for documentation dependencies [2026-05-03]
-- [ ] Create `.readthedocs.yaml` configuration
-- [ ] Integrate ReadTheDocs with GitHub Actions
+- [x] Create `.readthedocs.yaml` configuration [2026-05-03]
+- [x] Integrate ReadTheDocs with GitHub Actions [2026-05-03]
 - [ ] Verify automatic documentation updates on ReadTheDocs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,3 +11,18 @@ nav:
   - Technical Debts: TECHNICAL_DEBTS.md
   - Specification:
     - Overview: specification/README.md
+    - RP2040 Datasheet:
+      - Introduction: specification/rp2040-datasheet/03_chapter_1_introduction.md
+      - System Description: specification/rp2040-datasheet/04_chapter_2_system_description/00_introduction.md
+      - Peripherals:
+        - Overview: specification/rp2040-datasheet/06_chapter_4_peripherals/00_introduction.md
+        - UART: specification/rp2040-datasheet/06_chapter_4_peripherals/02_4.2_uart.md
+        - PWM: specification/rp2040-datasheet/06_chapter_4_peripherals/05_4.5_pwm.md
+        - Timer: specification/rp2040-datasheet/06_chapter_4_peripherals/06_4.6_timer.md
+        - ADC: specification/rp2040-datasheet/06_chapter_4_peripherals/09_4.9_adc_and_temperature_sensor.md
+    - XIAO RP2040:
+      - Introduction: specification/xiao-rp2040/01_introduction.md
+      - Pin Map: specification/xiao-rp2040/05_pin_map.md
+    - SDKs:
+      - C/C++ SDK: specification/raspberry-pi-pico-c-sdk/01_raspberry_pi_pico_series_cc_sdk_libraries_and_tools_for_cc_development_on_raspberry_pi_microcontrollers.md
+      - Python SDK: specification/raspberry-pi-pico-python-sdk/01_raspberry_pi_pico_series_python_sdk_a_micropython_environment_for_raspberry_pi_microcontrollers.md


### PR DESCRIPTION
This change completes the "Create .readthedocs.yaml configuration" and "Integrate ReadTheDocs with GitHub Actions" steps from Phase 6 of the ROADMAP.md. 

Key changes include:
1. **ReadTheDocs Configuration**: Added `.readthedocs.yaml` to the root directory, specifying Python 3.10 and installing dependencies from `docs/requirements.txt`.
2. **CI Integration**: Added a "Build Documentation" step to `.github/workflows/ci.yml` that executes `mkdocs build` on every push and pull request. This ensures that documentation remains buildable and consistent.
3. **Navigation Improvements**: Updated `mkdocs.yml` to include a comprehensive navigation structure for the `specification/` directory, including the RP2040 datasheet and XIAO RP2040 specifics.
4. **Environment Cleanup**: Added the `site/` directory to `.gitignore` to prevent generated documentation artifacts from being committed.
5. **Roadmap Update**: Marked the corresponding tasks as completed in `ROADMAP.md`.

All changes were verified by successfully running `mkdocs build` and the full Renode test suite locally.

Fixes #66

---
*PR created automatically by Jules for task [12332345038696474788](https://jules.google.com/task/12332345038696474788) started by @chatelao*