### PR TITLE
Verify PWM specs and add tasks for implementation gaps

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -90,3 +90,11 @@ The final plan to implement the `CONCEPT.md` and `DESIGN.md` to achieve the top 
 - [ ] Implement PIO (Programmable I/O) state machine examples
 - [ ] Optimize Renode simulation parameters for better host performance
 - [ ] Expand `full_suite.robot` with advanced stress tests
+
+## Phase 11: Full PWM Feature Support
+- [ ] Implement 16-bit dynamic counter in `RP2040PWM` Renode model
+- [ ] Implement double buffering for `CC` and `TOP` registers (latched update on wrap)
+- [ ] Implement `DIVMODE` support for LEVEL, RISE, and FALL input modes
+- [ ] Implement IRQ and DREQ signal assertion on counter wrap
+- [ ] Implement `PH_ADV` and `PH_RET` phase adjustment logic
+- [ ] Create Robot Framework tests for advanced PWM features (interrupts, inputs)

--- a/docs/TECHNICAL_DEBTS.md
+++ b/docs/TECHNICAL_DEBTS.md
@@ -3,3 +3,11 @@
 List of technical debts identified during the project.
 
 - **Framework Deviation:** Using `arduino` framework instead of `pico-sdk` as initially planned in `DESIGN.md`. This was chosen because the Seeed Studio PlatformIO platform recommends it and it was easier to verify the basic setup. Transitioning to `pico-sdk` remains a future goal.
+
+- **PWM Implementation Gaps:** The current `RP2040PWM` Renode model is a simplified functional representation and lacks several hardware features:
+    - **Double Buffering:** `CC` and `TOP` registers update immediately instead of being latched and updated only on counter wrap.
+    - **Dynamic Counter:** The model uses a static frequency/duty cycle calculation rather than a cycle-accurate 16-bit incrementing counter.
+    - **Input Modes:** `DIVMODE` settings (LEVEL, RISE, FALL) that use the B pin as a clock gate or clock source are not implemented.
+    - **Phase Adjustment:** `PH_ADV` and `PH_RET` bits are non-functional.
+    - **Interrupt/DMA Triggering:** IRQ and DREQ signals are not asserted on counter wrap.
+    - **CSR Bit Mapping:** The `CHx_CSR` register bit mapping is currently shifted: Bits 2-3 are mapped to `DIVMODE` (should be 4-5), Bit 4 to `A_INV` (should be 2), and Bit 5 to `B_INV` (should be 3).


### PR DESCRIPTION
This PR documents the discrepancies between the current `RP2040PWM` Renode model and the official RP2040 hardware specifications. It updates the project's technical debt list and roadmap to ensure these gaps are addressed in future development phases. No functional code changes were made; only documentation and planning files were updated. Existing tests were run to ensure zero impact on the current simulation stability.

Fixes #70

---
*PR created automatically by Jules for task [4384213365830651848](https://jules.google.com/task/4384213365830651848) started by @chatelao*