### PR TITLE
Document ADC implementation gaps and add roadmap tasks

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -98,3 +98,12 @@ The final plan to implement the `CONCEPT.md` and `DESIGN.md` to achieve the top 
 - [ ] Implement IRQ and DREQ signal assertion on counter wrap
 - [ ] Implement `PH_ADV` and `PH_RET` phase adjustment logic
 - [ ] Create Robot Framework tests for advanced PWM features (interrupts, inputs)
+
+## Phase 12: Full ADC Feature Support
+- [ ] Fix round-robin logic in `RP2040ADC` to correctly cycle through enabled channels
+- [ ] Implement error generation logic and propagate `ERR` bits to status and FIFO
+- [ ] Correct `READY` flag behavior to remain high during pacing timer delays
+- [ ] Refactor pacing timer to define the total sampling interval (96 cycles vs `DIV` setting)
+- [ ] Implement correct `FIFO` register bit packing including bit 15 (`ERR`)
+- [ ] Align `DMARequest` (DREQ) signaling with `FCS.THRESH` and `FCS.DREQ_EN` logic
+- [ ] Create Robot Framework tests for round-robin sampling and pacing timer accuracy

--- a/docs/TECHNICAL_DEBTS.md
+++ b/docs/TECHNICAL_DEBTS.md
@@ -11,3 +11,11 @@ List of technical debts identified during the project.
     - **Phase Adjustment:** `PH_ADV` and `PH_RET` bits are non-functional.
     - **Interrupt/DMA Triggering:** IRQ and DREQ signals are not asserted on counter wrap.
     - **CSR Bit Mapping:** The `CHx_CSR` register bit mapping is currently shifted: Bits 2-3 are mapped to `DIVMODE` (should be 4-5), Bit 4 to `A_INV` (should be 2), and Bit 5 to `B_INV` (should be 3).
+
+- **ADC Implementation Gaps:** The current `RP2040ADC` Renode model has several functional gaps compared to the RP2040 datasheet:
+    - **Broken Round-Robin Logic:** The `IterateInput` method starts searching from the current `selectedInput`, causing it to get stuck on the same channel if it is included in the `RROBIN` mask.
+    - **Missing Error Handling:** There is no logic to generate or propagate the `ERR` bit in the `CS` status or the `FIFO` register, although the registers and fields are defined.
+    - **Inaccurate READY Behavior:** The `READY` flag remains low during pacing timer delays, whereas it should be high whenever the ADC is not actively performing a conversion.
+    - **Pacing Timer Implementation:** The model adds the pacing delay *before* the 96-cycle sampling period instead of using it to define the total trigger interval (`1 + INT + FRAC / 256`).
+    - **FIFO Register Bit Packing:** The `FIFO` register read logic does not correctly pack the `ERR` bit (bit 15) when `FCS.ERR` is enabled.
+    - **DREQ Logic:** The `DMARequest` signal toggles on every sample produced, ignoring the `FCS.THRESH` setting.


### PR DESCRIPTION
Verified the RP2040 ADC Renode implementation against Chapter 4.9 of the datasheet and documented identified functional gaps in `TECHNICAL_DEBTS.md` and `ROADMAP.md`. Key issues include broken round-robin logic, missing error handling, inaccurate `READY` flag behavior, and pacing timer inaccuracies.

Fixes #72

---
*PR created automatically by Jules for task [5371784434600521866](https://jules.google.com/task/5371784434600521866) started by @chatelao*