### PR TITLE
Fix Peripheral Models and Refine Roadmap

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -108,8 +108,8 @@ The final plan to implement the `CONCEPT.md` and `DESIGN.md` to achieve the top 
 - [ ] Implement `PH_ADV` and `PH_RET` phase adjustment logic
 - [ ] Create Robot Framework tests for advanced PWM features (interrupts, inputs)
 
-## Phase 12: Full ADC Feature Support
-- [ ] Fix round-robin logic in `RP2040ADC` to correctly cycle through enabled channels
+## Phase 13: Full ADC Feature Support
+- [x] Fix round-robin logic in `RP2040ADC` to correctly cycle through enabled channels [2026-05-04]
 - [ ] Implement error generation logic and propagate `ERR` bits to status and FIFO
 - [ ] Correct `READY` flag behavior to remain high during pacing timer delays
 - [ ] Refactor pacing timer to define the total sampling interval (96 cycles vs `DIV` setting)

--- a/docs/TECHNICAL_DEBTS.md
+++ b/docs/TECHNICAL_DEBTS.md
@@ -10,10 +10,8 @@ List of technical debts identified during the project.
     - **Input Modes:** `DIVMODE` settings (LEVEL, RISE, FALL) that use the B pin as a clock gate or clock source are not implemented.
     - **Phase Adjustment:** `PH_ADV` and `PH_RET` bits are non-functional.
     - **Interrupt/DMA Triggering:** IRQ and DREQ signals are not asserted on counter wrap.
-    - **CSR Bit Mapping:** The `CHx_CSR` register bit mapping is currently shifted: Bits 2-3 are mapped to `DIVMODE` (should be 4-5), Bit 4 to `A_INV` (should be 2), and Bit 5 to `B_INV` (should be 3).
 
 - **ADC Implementation Gaps:** The current `RP2040ADC` Renode model has several functional gaps compared to the RP2040 datasheet:
-    - **Broken Round-Robin Logic:** The `IterateInput` method starts searching from the current `selectedInput`, causing it to get stuck on the same channel if it is included in the `RROBIN` mask.
     - **Missing Error Handling:** There is no logic to generate or propagate the `ERR` bit in the `CS` status or the `FIFO` register, although the registers and fields are defined.
     - **Inaccurate READY Behavior:** The `READY` flag remains low during pacing timer delays, whereas it should be high whenever the ADC is not actively performing a conversion.
     - **Pacing Timer Implementation:** The model adds the pacing delay *before* the 96-cycle sampling period instead of using it to define the total trigger interval (`1 + INT + FRAC / 256`).

--- a/test/renode-config/emulation/peripherals/adc/rp2040_adc.cs
+++ b/test/renode-config/emulation/peripherals/adc/rp2040_adc.cs
@@ -296,31 +296,12 @@ namespace Antmicro.Renode.Peripherals.Analog
     {
       if (roundRobinChannels != 0)
       {
-        byte firstChannel = channelsCount + 1;
-        byte lastChannel = 0;
-        for (byte i = 0; i < channelsCount; ++i)
+        for (int i = 1; i <= channelsCount; i++)
         {
-          if (BitHelper.IsBitSet(roundRobinChannels, i))
+          int nextChannel = (selectedInput + i) % channelsCount;
+          if (BitHelper.IsBitSet(roundRobinChannels, (byte)nextChannel))
           {
-            if (firstChannel > channelsCount)
-            {
-              firstChannel = i;
-            }
-            lastChannel = i;
-          }
-        }
-
-        if (selectedInput >= lastChannel)
-        {
-          selectedInput = firstChannel;
-          return;
-        }
-
-        for (byte c = selectedInput; c < channelsCount; ++c)
-        {
-          if (BitHelper.IsBitSet(roundRobinChannels, c))
-          {
-            selectedInput = c;
+            selectedInput = (byte)nextChannel;
             return;
           }
         }

--- a/test/renode-config/emulation/peripherals/pwm/rp2040_pwm.cs
+++ b/test/renode-config/emulation/peripherals/pwm/rp2040_pwm.cs
@@ -45,9 +45,9 @@ namespace Antmicro.Renode.Peripherals.PWM
             {
                 reg.WithFlag(0, out slices[index].enabled, name: $"CH{index}_CSR_EN", writeCallback: (_, __) => slices[index].Update())
                    .WithFlag(1, out slices[index].phaseCorrect, name: $"CH{index}_CSR_PH_CORRECT", writeCallback: (_, __) => slices[index].Update())
-                   .WithValueField(2, 2, out slices[index].divMode, name: $"CH{index}_CSR_DIVMODE")
-                   .WithFlag(4, out slices[index].invertA, name: $"CH{index}_CSR_A_INV", writeCallback: (_, __) => slices[index].Update())
-                   .WithFlag(5, out slices[index].invertB, name: $"CH{index}_CSR_B_INV", writeCallback: (_, __) => slices[index].Update())
+                   .WithFlag(2, out slices[index].invertA, name: $"CH{index}_CSR_A_INV", writeCallback: (_, __) => slices[index].Update())
+                   .WithFlag(3, out slices[index].invertB, name: $"CH{index}_CSR_B_INV", writeCallback: (_, __) => slices[index].Update())
+                   .WithValueField(4, 2, out slices[index].divMode, name: $"CH{index}_CSR_DIVMODE")
                    .WithFlag(6, name: $"CH{index}_CSR_TOP_SEL")
                    .WithFlag(7, name: $"CH{index}_CSR_ADVANCE")
                    .WithReservedBits(8, 24);

--- a/test/renode-config/emulation/peripherals/timer/rp2040_timer.cs
+++ b/test/renode-config/emulation/peripherals/timer/rp2040_timer.cs
@@ -62,7 +62,7 @@ namespace Antmicro.Renode.Peripherals.Timers
                 }
                 else
                 {
-                    ticksToWait = (0x100000000ULL - currentLow) + limitLow;
+                    ticksToWait = (0x100000000UL - currentLow) + limitLow;
                 }
 
                 // Ensure we wait at least one tick to avoid instant firing issues in some engines


### PR DESCRIPTION
This PR implements modest but critical fixes for the RP2040 peripheral simulation models (ADC, PWM, and Timer) and refines the project roadmap.

Key changes:
1. **ADC Fix**: The `IterateInput` method in `RP2040ADC` was updated to use a modulo-based approach, ensuring it correctly cycles through all enabled channels in round-robin mode.
2. **PWM Fix**: The bit mapping for `CHx_CSR` in `RP2040PWM` was corrected to align with the RP2040 datasheet (A_INV bit 2, B_INV bit 3, DIVMODE bits 4-5).
3. **Timer Fix**: Corrected a 64-bit integer literal suffix from `ULL` to `UL` in `RP2040Timer.cs` to resolve a C# compilation error.
4. **Documentation**:
    - Renumbered Phase 12 to Phase 13 in `ROADMAP.md` for better logical flow.
    - Marked the ADC round-robin fix as completed.
    - Updated `TECHNICAL_DEBTS.md` by removing the resolved issues.
    - Ensured root-level symbolic links for documentation are correctly maintained.

All changes were verified using the `test/full_suite.robot` test suite in Renode.

Fixes #84

---
*PR created automatically by Jules for task [11178131959632424334](https://jules.google.com/task/11178131959632424334) started by @chatelao*