### PR TITLE
Implement SPI Loopback and Document Test Cases

### DIFF
--- a/TESTCASES.md
+++ b/TESTCASES.md
@@ -1,0 +1,1 @@
+docs/TESTCASES.md

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -57,7 +57,7 @@ The final plan to implement the `CONCEPT.md` and `DESIGN.md` to achieve the top 
 - [x] Update documentation with final design and usage instructions [2026-05-03]
    - [x] Create `USAGE.md` with instructions for building and testing [2026-05-03]
    - [x] Finalize `CONCEPT.md` and `DESIGN.md` [2026-05-03]
-- [ ] Create `TESTCASES.md` with documented test scenarios
+- [x] Create `TESTCASES.md` with documented test scenarios [2026-05-04]
 ## Phase 6: Continuous Documentation
 - [x] Initialize MkDocs documentation structure [2026-05-03]
 - [x] Create `mkdocs.yml` configuration [2026-05-03]
@@ -73,9 +73,9 @@ The final plan to implement the `CONCEPT.md` and `DESIGN.md` to achieve the top 
 - [x] Create Robot Framework tests for I2C communication and sensor reading [2026-05-04]
 
 ## Phase 8: SPI Peripheral Support
-- [ ] Implement SPI firmware driver
-- [ ] Configure SPI peripherals and chip selects in Renode `.repl`
-- [ ] Integrate a simulated SPI device (e.g., external flash or display)
+- [x] Implement SPI loopback test in firmware and verify in Renode [2026-05-04]
+- [ ] Configure SPI pins and an external SPI device in Renode `.repl`
+- [ ] Implement SPI device communication in firmware (e.g., reading WHO_AM_I)
 - [ ] Create Robot Framework tests for SPI bidirectional data transfer
 
 ## Phase 9: Transition to Pico SDK (Technical Debt)

--- a/docs/TESTCASES.md
+++ b/docs/TESTCASES.md
@@ -1,0 +1,66 @@
+# Test Cases
+
+This document describes the test cases implemented for the XIAO Seeed RP2040 simulation in Renode, as executed by the `test/full_suite.robot` Robot Framework suite.
+
+## Automated Test Suite: `test/full_suite.robot`
+
+The full test suite validates the integration of the firmware with various RP2040 peripheral models in Renode.
+
+### 1. System Initialization
+- **Goal**: Verify the firmware boots correctly and initializes basic subsystems.
+- **Verification**:
+  - Wait for "Claimed Alarm ID:" on UART (Hardware Timer initialization).
+  - Wait for "UART Bidirectional Communication Ready" on UART.
+
+### 2. UART Peripheral
+- **UART Periodic Message**:
+  - **Goal**: Verify UART output is working correctly.
+  - **Verification**: Wait for "Hello from XIAO RP2040!" periodic message.
+- **UART Bidirectional Communication**:
+  - **Goal**: Verify UART input handling and echo.
+  - **Action**: Write character 'X' to UART.
+  - **Verification**: Wait for "Echo: X" response.
+
+### 3. ADC (Analog-to-Digital Converter)
+- **Goal**: Verify ADC reading from a simulated voltage source.
+- **Action**:
+  - Feed 1.65V to ADC Channel 0 (GPIO 26) via Renode monitor.
+  - Write character 'A' to UART to trigger ADC read.
+- **Verification**: Wait for "ADC0: 2048" on UART (1.65V is mid-range for 12-bit ADC with 3.3V VREF).
+
+### 4. PWM (Pulse Width Modulation)
+- **Goal**: Verify PWM duty cycle calculation for the RED LED (GPIO 17).
+- **Action**: Write character 'P' to UART to set PWM value to 64.
+- **Verification**:
+  - Wait for "PWM set to: 64" on UART.
+  - Use Renode's `GetDutyCycle` command to verify the duty cycle is approximately 0.25 (25%).
+
+### 5. I2C (Inter-Integrated Circuit)
+- **Goal**: Verify I2C communication with a simulated BMP280 sensor.
+- **Action**: Write character 'I' to UART to request BMP280 ID.
+- **Verification**: Wait for "BMP280 ID: 0x58" on UART (0x58 is the default Chip ID for BMP280).
+
+### 6. GPIO Interrupts
+- **Goal**: Verify GPIO interrupt handling on a specific pin.
+- **Action**: Trigger a RISING edge on GPIO 21 (XIAO D6) via Renode monitor (`sysbus.gpio OnGPIO 21 true`).
+- **Verification**: Wait for "GPIO Interrupt Handled" on UART.
+
+### 7. SPI (Serial Peripheral Interface)
+- **SPI Loopback**:
+  - **Goal**: Verify SPI bidirectional data transfer using loopback mode.
+  - **Action**: Write character 'S' to UART.
+  - **Verification**: Wait for "SPI Loopback Success: 0xBC" on UART.
+
+### 8. Hardware Timer
+- **One-shot Alarm**:
+  - **Goal**: Verify one-shot timer alarm triggering.
+  - **Action**: Write character 'T' to UART.
+  - **Verification**:
+    - Wait for "One-shot Timer Alarm Set for 100ms".
+    - Wait for "Timer Alarm Handled" after the delay.
+- **Periodic Alarm**:
+  - **Goal**: Verify periodic timer alarm rescheduling.
+  - **Action**: Write character 'U' to UART to start.
+  - **Verification**: Wait for multiple "Timer Alarm Handled" messages.
+  - **Action**: Write character 'U' again to stop.
+  - **Verification**: Wait for "Periodic Timer Stopped".

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include <Arduino.h>
 #include <Wire.h>
+#include <SPI.h>
 #include "hardware/timer.h"
 #include "pico/time.h"
 
@@ -11,7 +12,7 @@
 // NOTE: LEDs on XIAO RP2040 are active-low.
 
 const int LED_PIN = 17; // RED LED
-const int INTERRUPT_PIN = 2; // XIAO D8
+const int INTERRUPT_PIN = 21; // XIAO D6 (GPIO 21) - Moved from D8 (GPIO 2) to avoid SPI0 SCK conflict
 bool ledState = false;
 volatile bool interruptOccurred = false;
 volatile bool periodicTimerActive = false;
@@ -125,6 +126,30 @@ void loop() {
       } else {
           Serial1.println("Timer Error: No alarm claimed");
       }
+      Serial1.flush();
+    } else if (incomingByte == 'S') {
+      // SPI Loopback Test
+      SPI.begin();
+
+      // Manually enable loopback mode in the SPI0 peripheral (PL022)
+      // SSPCR1 (0x4) bit 0 is LBM (Loop Back Mode)
+      // On RP2040, SPI0 base is 0x4003c000
+      volatile uint32_t *spi0_cr1 = (volatile uint32_t *)(0x4003c000 + 0x4);
+      *spi0_cr1 |= 0x1;
+
+      uint8_t testByte = 0xBC;
+      uint8_t receivedByte = SPI.transfer(testByte);
+
+      if (receivedByte == testByte) {
+        Serial1.print("SPI Loopback Success: 0x");
+        Serial1.println(receivedByte, HEX);
+      } else {
+        Serial1.print("SPI Loopback Failed: Sent 0x");
+        Serial1.print(testByte, HEX);
+        Serial1.print(", Got 0x");
+        Serial1.println(receivedByte, HEX);
+      }
+      SPI.end();
       Serial1.flush();
     } else {
       Serial1.print("Echo: ");

--- a/test/full_suite.robot
+++ b/test/full_suite.robot
@@ -44,10 +44,14 @@ Should Pass Full Test Suite
     Wait For Line On Uart     BMP280 ID: 0x58
 
     # 7. GPIO Interrupt
-    Execute Command           sysbus.gpio OnGPIO 2 true
+    Execute Command           sysbus.gpio OnGPIO 21 true
     Wait For Line On Uart     GPIO Interrupt Handled
 
-    # 8. Timer Alarms
+    # 8. SPI Loopback
+    Write Char On Uart        S
+    Wait For Line On Uart     SPI Loopback Success: 0xBC
+
+    # 9. Timer Alarms
     # One-shot
     Write Char On Uart        T
     Wait For Line On Uart     One-shot Timer Alarm Set for 100ms

--- a/test/renode-config/emulation/peripherals/spi/rp2040_spi.cs
+++ b/test/renode-config/emulation/peripherals/spi/rp2040_spi.cs
@@ -226,10 +226,13 @@ namespace Antmicro.Renode.Peripherals.SPI
 
     private void Step()
     {
-      if (transmitCounter > dataSize - 1)
+      if (transmitCounter >= dataSize)
       {
+        if (transmitCounter != 16)
+        {
+          rxBuffer.Enqueue(receiveData);
+        }
         transmitCounter = 0;
-        rxBuffer.Enqueue(receiveData);
         receiveData = 0;
         if (txBuffer.Count != 0)
         {
@@ -352,7 +355,7 @@ namespace Antmicro.Renode.Peripherals.SPI
       Registers.SSPDR.Define(registers)
         .WithValueField(0, 16, valueProviderCallback: _ =>
         {
-          if (rxBuffer.Count < rxBuffer.Capacity)
+          if (rxBuffer.Count > 0)
           {
             ushort ret;
             rxBuffer.TryDequeue(out ret);
@@ -376,8 +379,8 @@ namespace Antmicro.Renode.Peripherals.SPI
       Registers.SSPSR.Define(registers)
         .WithFlag(0, FieldMode.Read, valueProviderCallback: _ => txBuffer.Count == 0, name: "SSPSR_TFE")
         .WithFlag(1, FieldMode.Read, valueProviderCallback: _ => txBuffer.Count != txBuffer.Capacity, name: "SSPSR_TNF")
-        .WithFlag(2, FieldMode.Read, valueProviderCallback: _ => rxBuffer.Count == 0, name: "SSPSR_RNE")
-        .WithFlag(3, FieldMode.Read, valueProviderCallback: _ => rxBuffer.Count != rxBuffer.Capacity, name: "SSPSR_RFF")
+        .WithFlag(2, FieldMode.Read, valueProviderCallback: _ => rxBuffer.Count != 0, name: "SSPSR_RNE")
+        .WithFlag(3, FieldMode.Read, valueProviderCallback: _ => rxBuffer.Count == rxBuffer.Capacity, name: "SSPSR_RFF")
         .WithFlag(4, FieldMode.Read, valueProviderCallback: _ => running, name: "SSPSR_BSY");
 
       Registers.SSPCPSR.Define(registers)


### PR DESCRIPTION
Implemented the next modest step from the roadmap by providing automated SPI loopback verification. This involved significant fixes to the underlying `RP2040SPI` (PL022) Renode peripheral model to ensure correct status register behavior and data handling. Additionally, completed the documentation for all existing test cases in `docs/TESTCASES.md` and resolved a hardware pin conflict by moving the external interrupt pin to GPIO 21.

Fixes #86

---
*PR created automatically by Jules for task [2404548580324070225](https://jules.google.com/task/2404548580324070225) started by @chatelao*