### PR TITLE
Implement RP2040 Watchdog support

### DIFF
--- a/docs/FEATURE_COVERAGE.md
+++ b/docs/FEATURE_COVERAGE.md
@@ -41,7 +41,7 @@ This document tracks the implementation status of RP2040 features in the Renode 
 | 4.4 SPI | ⚠️ | Loopback mode supported and verified. |
 | 4.5 PWM | ⚠️ | Functional slices with CSR, DIV, CTR, TOP, CC registers. Missing: double buffering, dynamic 16-bit counter, phase adjustment, and wrap IRQs. |
 | 4.6 Timer | ✅ | 64-bit counter, 4 alarms with IRQ support (0-3). |
-| 4.7 Watchdog | ❌ | n/a |
+| 4.7 Watchdog | ✅ | Watchdog timer with reboot support verified. |
 | 4.8 RTC | ❌ | n/a |
 | 4.9 ADC | ⚠️ | Voltage sampling on 5 channels. Support for error bits, FIFO packing, and DREQ signaling implemented; tests still require stabilization. |
 | 4.10 SSI | ❌ | n/a |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -129,10 +129,12 @@ The final plan to implement the `CONCEPT.md` and `DESIGN.md` to achieve the top 
 - [ ] Fix stability of ADC error detection and threshold logic tests
 
 ## Phase 15: Watchdog and RTC Support
-- [ ] Implement `RP2040Watchdog` Renode model for system supervisor
+- [x] Implement `RP2040Watchdog` Renode model for system supervisor [2026-05-05]
 - [ ] Implement `RP2040RTC` Renode model for real-time clock functionality
-- [ ] Create firmware examples for Watchdog timeout and RTC alarm
-- [ ] Create Robot Framework tests for Watchdog and RTC
+- [x] Create firmware examples for Watchdog timeout [2026-05-05]
+- [ ] Create firmware examples for RTC alarm
+- [x] Create Robot Framework tests for Watchdog [2026-05-05]
+- [ ] Create Robot Framework tests for RTC
 
 ## Phase 16: System Resets and Power Management
 - [ ] Implement `RP2040Resets` Renode model for peripheral reset control

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include "hardware/timer.h"
 #include "hardware/adc.h"
 #include "hardware/pio.h"
+#include "hardware/watchdog.h"
 #include "pico/time.h"
 #include "blink.pio.h"
 
@@ -40,6 +41,10 @@ void on_timer_alarm(uint alarm_num) {
 void setup() {
   // Use Serial1 for hardware UART output (mapped to sysbus.uart0 in Renode)
   Serial1.begin(115200);
+
+  if (watchdog_caused_reboot()) {
+    Serial1.println("Watchdog Reboot Detected");
+  }
 
   // Initialize I2C
   Wire.begin();
@@ -206,6 +211,14 @@ void loop() {
         digitalWrite(GREEN_LED_PIN, HIGH); // Off
         Serial1.println("PIO Blinking Stopped");
       }
+      Serial1.flush();
+    } else if (incomingByte == 'W') {
+      watchdog_enable(500, 1);
+      Serial1.println("Watchdog Enabled (500ms)");
+      Serial1.flush();
+    } else if (incomingByte == 'K') {
+      watchdog_update();
+      Serial1.println("Watchdog Kicked");
       Serial1.flush();
     } else {
       Serial1.print("Echo: ");

--- a/test/full_suite.robot
+++ b/test/full_suite.robot
@@ -74,6 +74,21 @@ Should Pass Full Test Suite
     Write Char On Uart        B
     Wait For Line On Uart     PIO Blinking Stopped
 
+    # 11. Watchdog
+    # Enable watchdog
+    Write Char On Uart        W
+    Wait For Line On Uart     Watchdog Enabled (500ms)
+
+    # Kick watchdog after 200ms
+    Sleep                     0.2
+    Write Char On Uart        K
+    Wait For Line On Uart     Watchdog Kicked
+
+    # Wait for reboot (expecting "Watchdog Reboot Detected")
+    Wait For Line On Uart     Watchdog Reboot Detected
+    Wait For Line On Uart     Claimed Alarm ID:
+    Wait For Line On Uart     UART Bidirectional Communication Ready
+
 *** Keywords ***
 Create Machine
     Execute Command           $global.TEST_FILE = @${FIRMWARE}

--- a/test/renode-config/emulation/peripherals/watchdog/rp2040_watchdog.cs
+++ b/test/renode-config/emulation/peripherals/watchdog/rp2040_watchdog.cs
@@ -53,6 +53,7 @@ namespace Antmicro.Renode.Peripherals.Timers
             {
                 this.Log(LogLevel.Debug, "Watchdog disabled due to lack of cycles configuration");
                 timer.Enabled = false;
+                return;
             }
 
             // * 2 due to bug in RP2040, please check errrata RP2040-E1 inside datasheet
@@ -77,7 +78,7 @@ namespace Antmicro.Renode.Peripherals.Timers
                 .WithFlag(30, writeCallback: (_, value) =>
                 {
                     timer.Enabled = value;
-                    this.Log(LogLevel.Debug, "Watchdog enable: {0}", value);
+                    this.Log(LogLevel.Info, "Watchdog enable: {0}", value);
                 }, valueProviderCallback: _ => timer.Enabled, name: "ENABLED")
                 .WithFlag(31, FieldMode.Write, writeCallback: (_, value) =>
                 {


### PR DESCRIPTION
This PR implements the Watchdog support for the RP2040 as part of Phase 15 of the roadmap. 

Changes:
1. **Firmware (`src/main.cpp`)**: Added detection of watchdog reboots in `setup()` and UART command handlers for enabling (`W`) and kicking (`K`) the watchdog.
2. **Renode Model (`rp2040_watchdog.cs`)**: Fixed a bug where a zero-cycle configuration would not exit early in `UpdateTimerFrequency`. Also increased the log level of the "Watchdog enable" message to `Info` to ensure it's visible in test logs.
3. **Tests (`test/full_suite.robot`)**: Added a new test section that verifies:
   - Enabling the watchdog.
   - Kicking the watchdog before timeout.
   - Verifying system reboot and reboot reason detection after timeout.
4. **Documentation**: Updated `ROADMAP.md` and `FEATURE_COVERAGE.md` to reflect the implemented and verified status of the Watchdog peripheral.

All tests in the unified suite pass successfully.

Fixes #100

---
*PR created automatically by Jules for task [7220162525731315488](https://jules.google.com/task/7220162525731315488) started by @chatelao*