### PR TITLE
docs: Add GLOSSARY.md with project and technical terms

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -1,0 +1,1 @@
+docs/GLOSSARY.md

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,0 +1,25 @@
+# Glossary
+
+## Project Management
+
+- **Concept**: A high-level document outlining the overall structure, goals, business cases, and use cases of the project.
+- **Design**: A detailed architectural document describing technological choices, interfaces, and implementation details.
+- **Roadmap**: A strategic plan that defines the phases and milestones required to achieve the project goals.
+- **Technical Debt**: A concept in software development that reflects the implied cost of additional rework caused by choosing an easy or limited solution now instead of using a better approach that would take longer.
+- **CI/CD (Continuous Integration / Continuous Deployment)**: The practice of automating the integration of code changes from multiple contributors into a single software project, and the subsequent automated delivery/deployment.
+
+## Technical Documentation
+
+- **RP2040**: A low-cost, high-performance microcontroller chip designed by Raspberry Pi, featuring dual ARM Cortex-M0+ cores.
+- **Renode**: An open-source simulation framework for multi-node hardware systems (embedded, IoT, etc.), developed by Antmicro.
+- **PlatformIO**: An open-source ecosystem for IoT development, including a cross-platform build system and library manager.
+- **Robot Framework**: A generic open-source automation framework for acceptance testing, acceptance test-driven development (ATDD), and robotic process automation (RPA).
+- **UART (Universal Asynchronous Receiver-Transmitter)**: A hardware device for asynchronous serial communication.
+- **ADC (Analog-to-Digital Converter)**: A system that converts an analog signal into a digital signal.
+- **PWM (Pulse Width Modulation)**: A technique for getting analog results with digital means, often used for controlling motors or LEDs.
+- **PIO (Programmable I/O)**: A versatile hardware subsystem on the RP2040 that can support a wide range of I/O standards.
+- **bEMF (Back Electromotive Force)**: The voltage that pushes back against the current which created it in an electric motor.
+- **.repl (Renode Platform)**: A file format used by Renode to describe the hardware platform, including peripherals and their memory mapping.
+- **.resc (Renode Script)**: A file format used by Renode to automate simulation setup, such as loading firmware and starting the execution.
+- **Pico SDK**: The C/C++ Software Development Kit for the RP2040 microcontroller.
+- **Arduino Framework**: A high-level abstraction layer that allows writing code using the Arduino API, often implemented on top of the Pico SDK for RP2040.

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -2,24 +2,33 @@
 
 ## Project Management
 
-- **Concept**: A high-level document outlining the overall structure, goals, business cases, and use cases of the project.
-- **Design**: A detailed architectural document describing technological choices, interfaces, and implementation details.
-- **Roadmap**: A strategic plan that defines the phases and milestones required to achieve the project goals.
-- **Technical Debt**: A concept in software development that reflects the implied cost of additional rework caused by choosing an easy or limited solution now instead of using a better approach that would take longer.
-- **CI/CD (Continuous Integration / Continuous Deployment)**: The practice of automating the integration of code changes from multiple contributors into a single software project, and the subsequent automated delivery/deployment.
+| Term | Definition |
+| :--- | :--- |
+| **Concept** | The overall structure of the product, including Business & Use Cases as well as the High-Level Architecture (defined in `CONCEPT.md`). |
+| **Design** | The detailed design of the solution, including the architecture, used tech stack for development, production and testing, etc. (defined in `DESIGN.md`). |
+| **Roadmap** | The list of accomplished and planned steps of the project (defined in `ROADMAP.md`). |
+| **TESTCASES.md** | The list of implemented and planned test cases of the project. |
+| **Technical Debt** | Log of outdated components, security flaws, old patterns, etc. that should be tracked in `TECHNICAL_DEBTS.md`. |
+| **CI/CD** | Continuous Integration / Continuous Deployment; the practice of automating code integration and delivery. |
+| **/src/** | The source code of the project. |
+| **/test/** | All tools, configurations & test cases. |
+| **/build/** | Only temporary place for compilation, may be cached by GitHub. |
 
 ## Technical Documentation
 
-- **RP2040**: A low-cost, high-performance microcontroller chip designed by Raspberry Pi, featuring dual ARM Cortex-M0+ cores.
-- **Renode**: An open-source simulation framework for multi-node hardware systems (embedded, IoT, etc.), developed by Antmicro.
-- **PlatformIO**: An open-source ecosystem for IoT development, including a cross-platform build system and library manager.
-- **Robot Framework**: A generic open-source automation framework for acceptance testing, acceptance test-driven development (ATDD), and robotic process automation (RPA).
-- **UART (Universal Asynchronous Receiver-Transmitter)**: A hardware device for asynchronous serial communication.
-- **ADC (Analog-to-Digital Converter)**: A system that converts an analog signal into a digital signal.
-- **PWM (Pulse Width Modulation)**: A technique for getting analog results with digital means, often used for controlling motors or LEDs.
-- **PIO (Programmable I/O)**: A versatile hardware subsystem on the RP2040 that can support a wide range of I/O standards.
-- **bEMF (Back Electromotive Force)**: The voltage that pushes back against the current which created it in an electric motor.
-- **.repl (Renode Platform)**: A file format used by Renode to describe the hardware platform, including peripherals and their memory mapping.
-- **.resc (Renode Script)**: A file format used by Renode to automate simulation setup, such as loading firmware and starting the execution.
-- **Pico SDK**: The C/C++ Software Development Kit for the RP2040 microcontroller.
-- **Arduino Framework**: A high-level abstraction layer that allows writing code using the Arduino API, often implemented on top of the Pico SDK for RP2040.
+| Term | Definition |
+| :--- | :--- |
+| **RP2040** | A low-cost, high-performance microcontroller chip designed by Raspberry Pi, featuring dual ARM Cortex-M0+ cores. |
+| **Renode** | An open-source simulation framework for multi-node hardware systems (embedded, IoT, etc.), developed by Antmicro. |
+| **PlatformIO** | An open-source ecosystem for IoT development, including a cross-platform build system and library manager. |
+| **Robot Framework** | A generic open-source automation framework for acceptance testing, acceptance test-driven development (ATDD), and robotic process automation (RPA). |
+| **UART** | Universal Asynchronous Receiver-Transmitter; a hardware device for asynchronous serial communication. |
+| **ADC** | Analog-to-Digital Converter; a system that converts an analog signal into a digital signal. |
+| **PWM** | Pulse Width Modulation; a technique for getting analog results with digital means, often used for controlling motors or LEDs. |
+| **PIO** | Programmable I/O; a versatile hardware subsystem on the RP2040 that can support a wide range of I/O standards. |
+| **bEMF** | Back Electromotive Force; the voltage that pushes back against the current which created it in an electric motor. |
+| **.repl** | Renode Platform; a file format used by Renode to describe the hardware platform, including peripherals and their memory mapping. |
+| **.resc** | Renode Script; a file format used by Renode to automate simulation setup, such as loading firmware and starting the execution. |
+| **Pico SDK** | The C/C++ Software Development Kit for the RP2040 microcontroller. |
+| **Arduino Framework** | A high-level abstraction layer that allows writing code using the Arduino API, often implemented on top of the Pico SDK for RP2040. |
+| **/specification/** | External Know-How as datasheet, standards, etc. Should be converted to Markdown if PDF, etc. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
   - Technical Debts: TECHNICAL_DEBTS.md
   - Feature Coverage: FEATURE_COVERAGE.md
   - BEMF Loop: BEMF_LOOP.md
+  - Glossary: GLOSSARY.md
   - Specification:
     - Overview: specification/README.md
     - RP2040 Datasheet:


### PR DESCRIPTION
Created docs/GLOSSARY.md with definitions categorized into Project Management and Technical Documentation sections. Added a symbolic link in the root and updated mkdocs.yml for site navigation.

Fixes #103

---
*PR created automatically by Jules for task [286408264716741568](https://jules.google.com/task/286408264716741568) started by @chatelao*