### PR TITLE
Integrate BEMF loop example into CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,10 @@ jobs:
       run: |
         pio run
 
+    - name: Build BEMF Loop Example
+      run: |
+        pio run -d examples/bemf_loop
+
     - name: Build Documentation
       run: |
         pip install -r docs/requirements.txt
@@ -61,3 +65,7 @@ jobs:
     - name: Run Full Test Suite
       run: |
         ./test/renode/renode-test test/full_suite.robot
+
+    - name: Run BEMF Loop Test
+      run: |
+        ./test/renode/renode-test test/bemf_loop.robot

--- a/test/bemf_loop.robot
+++ b/test/bemf_loop.robot
@@ -7,6 +7,7 @@ Resource        ${RENODEKEYWORDS}
 *** Variables ***
 ${UART}         sysbus.uart0
 ${RESC}         ${CURDIR}/../examples/bemf_loop/bemf_example.resc
+${FIRMWARE}     ${CURDIR}/../examples/bemf_loop/.pio/build/seeed-xiao-rp2040/firmware.elf
 
 *** Test Cases ***
 Verify bEMF Loop
@@ -22,10 +23,11 @@ Verify bEMF Loop
     Wait For Line On Uart     DUTY:100  timeout=10
 
     # After some time, BEMF should increase as duty cycle increases
-    # We look for a line where BEMF is significantly above 0
     Wait For Line On Uart     DUTY:200  timeout=10
-    Wait For Line On Uart     BEMF:([1-9][0-9]*)    treatAsRegexp=true
+
+    # Verify that BEMF is non-zero
+    Wait For Line On Uart     BEMF:[1-9][0-9]*    timeout=10  treatAsRegex=true
 
     # Verify that BEMF follows duty cycle ramp (roughly)
-    ${line}=    Wait For Line On Uart     DUTY:300  timeout=10
-    Should Match Regexp    ${line}    BEMF:([1-9][0-9]*)
+    Wait For Line On Uart     DUTY:300  timeout=20
+    Wait For Line On Uart     BEMF:[1-9][0-9]*    timeout=10  treatAsRegex=true


### PR DESCRIPTION
This change integrates the `examples/bemf_loop` motor control example into the automated CI/CD pipeline. 

Key changes:
1. **CI Workflow**: Added `pio run -d examples/bemf_loop` and `renode-test test/bemf_loop.robot` to the `.github/workflows/ci.yml` file.
2. **Test Robustness**: Fixed `test/bemf_loop.robot` to use the correct `treatAsRegex=true` argument and improved the validation sequence to ensure BEMF values are correctly detected as they ramp with the duty cycle.
3. **Developer Experience**: Added a default `${FIRMWARE}` variable to the Robot file, allowing developers to run the test locally with a simple `renode-test test/bemf_loop.robot` command if the binary is already built.

All tests, including the new BEMF loop test and the existing full peripheral suite, have been verified to pass in the simulation environment.

Fixes #112

---
*PR created automatically by Jules for task [4503024451731577778](https://jules.google.com/task/4503024451731577778) started by @chatelao*