### PR TITLE
Implement RP2040 RTC support

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -143,11 +143,11 @@ The final plan to implement the `CONCEPT.md` and `DESIGN.md` to achieve the top 
 
 ## Phase 15: Watchdog and RTC Support
 - [x] Implement `RP2040Watchdog` Renode model for system supervisor [2026-05-05]
-- [ ] Implement `RP2040RTC` Renode model for real-time clock functionality
+- [x] Implement `RP2040RTC` Renode model for real-time clock functionality [2026-05-06]
 - [x] Create firmware examples for Watchdog timeout [2026-05-05]
-- [ ] Create firmware examples for RTC alarm
+- [x] Create firmware examples for RTC alarm [2026-05-06]
 - [x] Create Robot Framework tests for Watchdog [2026-05-05]
-- [ ] Create Robot Framework tests for RTC
+- [x] Create Robot Framework tests for RTC [2026-05-06]
 
 ## Phase 16: System Resets and Power Management
 - [ ] Implement `RP2040Resets` Renode model for peripheral reset control

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,9 @@
 #include "hardware/pio.h"
 #include "hardware/pwm.h"
 #include "hardware/watchdog.h"
+#include "hardware/rtc.h"
 #include "pico/time.h"
+#include "pico/util/datetime.h"
 #include "blink.pio.h"
 
 // On XIAO RP2040:
@@ -27,6 +29,7 @@ volatile bool interruptOccurred = false;
 volatile bool periodicTimerActive = false;
 volatile int alarmCount = 0;
 volatile bool pwmInterruptOccurred = false;
+volatile bool rtcInterruptOccurred = false;
 int alarmId = -1;
 
 void handleInterrupt() {
@@ -36,6 +39,10 @@ void handleInterrupt() {
 void on_pwm_interrupt() {
     pwm_clear_irq(pwm_gpio_to_slice_num(LED_PIN));
     pwmInterruptOccurred = true;
+}
+
+void on_rtc_interrupt() {
+    rtcInterruptOccurred = true;
 }
 
 void on_timer_alarm(uint alarm_num) {
@@ -55,6 +62,9 @@ void setup() {
 
   // Initialize I2C
   Wire.begin();
+
+  // Initialize RTC
+  rtc_init();
 
   pinMode(LED_PIN, OUTPUT);
   digitalWrite(LED_PIN, HIGH); // Start with LED OFF
@@ -95,6 +105,12 @@ void loop() {
   if (pwmInterruptOccurred) {
     pwmInterruptOccurred = false;
     Serial1.println("PWM Interrupt Handled");
+    Serial1.flush();
+  }
+
+  if (rtcInterruptOccurred) {
+    rtcInterruptOccurred = false;
+    Serial1.println("RTC Alarm Handled");
     Serial1.flush();
   }
 
@@ -254,6 +270,62 @@ void loop() {
       int motorAdc = adc_read();
       Serial1.print("Motor ADC: ");
       Serial1.println(motorAdc);
+      Serial1.flush();
+    } else if (incomingByte == 'R') {
+      // RTC Test: Set and Get time
+      datetime_t t = {
+          .year  = 2024,
+          .month = 05,
+          .day   = 06,
+          .dotw  = 1, // Monday
+          .hour  = 12,
+          .min   = 00,
+          .sec   = 00
+      };
+      rtc_set_datetime(&t);
+      sleep_us(64); // Wait for clock domain crossing
+
+      rtc_get_datetime(&t);
+      char datetime_buf[64];
+      datetime_to_str(datetime_buf, sizeof(datetime_buf), &t);
+      Serial1.print("RTC Time Set: ");
+      Serial1.println(datetime_buf);
+
+      // Simple wait to see it increment (in a real test we'd poll or use alarms)
+      delay(1100);
+      rtc_get_datetime(&t);
+      datetime_to_str(datetime_buf, sizeof(datetime_buf), &t);
+      Serial1.print("RTC Time After 1s: ");
+      Serial1.println(datetime_buf);
+      Serial1.flush();
+    } else if (incomingByte == 'Q') {
+      // RTC Alarm Test
+      datetime_t t = {
+          .year  = 2024,
+          .month = 05,
+          .day   = 06,
+          .dotw  = 1,
+          .hour  = 12,
+          .min   = 00,
+          .sec   = 00
+      };
+      rtc_set_datetime(&t);
+      sleep_us(64);
+
+      datetime_t alarm = {
+          .year  = -1,
+          .month = -1,
+          .day   = -1,
+          .dotw  = -1,
+          .hour  = -1,
+          .min   = -1,
+          .sec   = 02
+      };
+
+      Serial1.println("Setting RTC Alarm...");
+      Serial1.flush();
+      rtc_set_alarm(&alarm, on_rtc_interrupt);
+      Serial1.println("RTC Alarm Set for +2s");
       Serial1.flush();
     } else {
       Serial1.print("Echo: ");

--- a/test/renode-config/cores/initialize_peripherals_source.resc
+++ b/test/renode-config/cores/initialize_peripherals_source.resc
@@ -56,6 +56,8 @@ include $ORIGIN/../emulation/peripherals/dma/rpdma.cs
 
 include $ORIGIN/../emulation/peripherals/watchdog/rp2040_watchdog.cs
 
+include $ORIGIN/../emulation/peripherals/rtc/rp2040_rtc.cs
+
 include $ORIGIN/../emulation/peripherals/i2c/rp2040_i2c.cs
 
 include $ORIGIN/../emulation/externals/pcf8523.cs

--- a/test/renode-config/cores/rp2040.repl
+++ b/test/renode-config/cores/rp2040.repl
@@ -206,6 +206,13 @@ watchdog: Timers.RP2040Watchdog @ sysbus 0x40058000 {
     clocks: clocks
 }
 
+rtc: Timers.RP2040RTC @ sysbus 0x4005c000 {
+    address: 0x4005c000
+}
+
+rtc:
+    IRQ -> nvic0@25
+
 i2c0: I2C.RP2040I2C @ sysbus 0x40044000 {
     gpio: gpio;
     id: 0;

--- a/test/renode-config/emulation/peripherals/rtc/rp2040_rtc.cs
+++ b/test/renode-config/emulation/peripherals/rtc/rp2040_rtc.cs
@@ -1,0 +1,358 @@
+/**
+ * rp2040_rtc.cs
+ *
+ * Copyright (c) 2024 Jules
+ *
+ * Distributed under the terms of the MIT License.
+ */
+
+using System;
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Core.Structure.Registers;
+using Antmicro.Renode.Logging;
+using Antmicro.Renode.Peripherals.Timers;
+using Antmicro.Renode.Time;
+
+namespace Antmicro.Renode.Peripherals.Timers
+{
+    public class RP2040RTC : RP2040PeripheralBase, IKnownSize
+    {
+        public RP2040RTC(IMachine machine, ulong address) : base(machine, address)
+        {
+            IRQ = new GPIO();
+            // clk_rtc is usually 46875Hz (from 12MHz XOSC / 256)
+            // The default CLKDIV_M1 is 46874 to get a 1Hz tick.
+            // We'll use a timer that fires every 1 second.
+            tickTimer = new LimitTimer(machine.ClockSource, 1, this, "rtc_tick", limit: 1, direction: Direction.Ascending, enabled: false, workMode: WorkMode.Periodic, eventEnabled: true);
+            tickTimer.LimitReached += OnTick;
+
+            DefineRegisters();
+            Reset();
+        }
+
+        public override void Reset()
+        {
+            base.Reset();
+            tickTimer.Enabled = false;
+            rtcActive = false;
+            rtcEnabled = false;
+            forceNotLeapYear = false;
+
+            year = 0;
+            month = 1;
+            day = 1;
+            dotw = 0;
+            hour = 0;
+            minute = 0;
+            second = 0;
+
+            matchActive = false;
+            matchEnabled = false;
+            yearMatchEnabled = false;
+            monthMatchEnabled = false;
+            dayMatchEnabled = false;
+            dotwMatchEnabled = false;
+            hourMatchEnabled = false;
+            minMatchEnabled = false;
+            secMatchEnabled = false;
+
+            irqYear = 0;
+            irqMonth = 0;
+            irqDay = 0;
+            irqDotw = 0;
+            irqHour = 0;
+            irqMin = 0;
+            irqSec = 0;
+
+            rawInterrupt = false;
+            interruptEnabled = false;
+            interruptForce = false;
+
+            UpdateInterrupts();
+        }
+
+        private void OnTick()
+        {
+            second++;
+            if (second >= 60)
+            {
+                second = 0;
+                minute++;
+                if (minute >= 60)
+                {
+                    minute = 0;
+                    hour++;
+                    if (hour >= 24)
+                    {
+                        hour = 0;
+                        dotw = (dotw + 1) % 7;
+                        day++;
+                        if (day > DaysInMonth(month, year))
+                        {
+                            day = 1;
+                            month++;
+                            if (month > 12)
+                            {
+                                month = 1;
+                                year++;
+                            }
+                        }
+                    }
+                }
+            }
+
+            CheckAlarm();
+        }
+
+        private int DaysInMonth(int m, int y)
+        {
+            switch (m)
+            {
+                case 1: return 31;
+                case 2: return IsLeapYear(y) ? 29 : 28;
+                case 3: return 31;
+                case 4: return 30;
+                case 5: return 31;
+                case 6: return 30;
+                case 7: return 31;
+                case 8: return 31;
+                case 9: return 30;
+                case 10: return 31;
+                case 11: return 30;
+                case 12: return 31;
+                default: return 31;
+            }
+        }
+
+        private bool IsLeapYear(int y)
+        {
+            if (forceNotLeapYear) return false;
+            // Datasheet: "If the current value of YEAR in SETUP_0 is evenly divisible by 4, a leap year is detected"
+            // "Since this is not always true (century years for example), the leap year checking can be forced off"
+            return (y % 4 == 0);
+        }
+
+        private void CheckAlarm()
+        {
+            bool match = false;
+            if (matchEnabled)
+            {
+                match = true;
+                if (yearMatchEnabled && year != irqYear) match = false;
+                if (monthMatchEnabled && month != irqMonth) match = false;
+                if (dayMatchEnabled && day != irqDay) match = false;
+                if (dotwMatchEnabled && dotw != irqDotw) match = false;
+                if (hourMatchEnabled && hour != irqHour) match = false;
+                if (minMatchEnabled && minute != irqMin) match = false;
+                if (secMatchEnabled && second != irqSec) match = false;
+            }
+
+            if (match != rawInterrupt)
+            {
+                rawInterrupt = match;
+                UpdateInterrupts();
+            }
+        }
+
+        private void UpdateInterrupts()
+        {
+            bool status = (rawInterrupt || interruptForce) && interruptEnabled;
+            IRQ.Set(status);
+        }
+
+        private void LoadFromSetup()
+        {
+            year = setupYear;
+            month = setupMonth;
+            day = setupDay;
+            dotw = setupDotw;
+            hour = setupHour;
+            minute = setupMin;
+            second = setupSec;
+            this.Log(LogLevel.Info, "RTC Loaded: {0}-{1:D2}-{2:D2} {3:D2}:{4:D2}:{5:D2} (DOTW {6})", year, month, day, hour, minute, second, dotw);
+            CheckAlarm();
+        }
+
+        private void DefineRegisters()
+        {
+            Registers.CLKDIV_M1.Define(this)
+                .WithValueField(0, 16, out clkDivM1, name: "CLKDIV_M1");
+
+            Registers.SETUP_0.Define(this)
+                .WithValueField(0, 5, writeCallback: (_, val) => setupDay = (int)val, valueProviderCallback: _ => (ulong)setupDay, name: "DAY")
+                .WithReservedBits(5, 3)
+                .WithValueField(8, 4, writeCallback: (_, val) => setupMonth = (int)val, valueProviderCallback: _ => (ulong)setupMonth, name: "MONTH")
+                .WithValueField(12, 12, writeCallback: (_, val) => setupYear = (int)val, valueProviderCallback: _ => (ulong)setupYear, name: "YEAR")
+                .WithReservedBits(24, 8);
+
+            Registers.SETUP_1.Define(this)
+                .WithValueField(0, 6, writeCallback: (_, val) => setupSec = (int)val, valueProviderCallback: _ => (ulong)setupSec, name: "SEC")
+                .WithReservedBits(6, 2)
+                .WithValueField(8, 6, writeCallback: (_, val) => setupMin = (int)val, valueProviderCallback: _ => (ulong)setupMin, name: "MIN")
+                .WithReservedBits(14, 2)
+                .WithValueField(16, 5, writeCallback: (_, val) => setupHour = (int)val, valueProviderCallback: _ => (ulong)setupHour, name: "HOUR")
+                .WithReservedBits(21, 3)
+                .WithValueField(24, 3, writeCallback: (_, val) => setupDotw = (int)val, valueProviderCallback: _ => (ulong)setupDotw, name: "DOTW")
+                .WithReservedBits(27, 5);
+
+            Registers.CTRL.Define(this)
+                .WithFlag(0, writeCallback: (_, val) => {
+                    rtcEnabled = val;
+                    tickTimer.Enabled = val;
+                    rtcActive = val;
+                    this.Log(LogLevel.Info, "RTC Enable: {0}", val);
+                }, valueProviderCallback: _ => rtcEnabled, name: "RTC_ENABLE")
+                .WithFlag(1, FieldMode.Read, valueProviderCallback: _ => rtcActive, name: "RTC_ACTIVE")
+                .WithReservedBits(2, 2)
+                .WithFlag(4, FieldMode.Write, writeCallback: (_, val) => {
+                    if (val) LoadFromSetup();
+                }, name: "LOAD")
+                .WithReservedBits(5, 3)
+                .WithFlag(8, writeCallback: (_, val) => forceNotLeapYear = val, valueProviderCallback: _ => forceNotLeapYear, name: "FORCE_NOTLEAPYEAR")
+                .WithReservedBits(9, 23);
+
+            Registers.IRQ_SETUP_0.Define(this)
+                .WithValueField(0, 5, writeCallback: (_, val) => { irqDay = (int)val; CheckAlarm(); }, valueProviderCallback: _ => (ulong)irqDay, name: "DAY")
+                .WithReservedBits(5, 3)
+                .WithValueField(8, 4, writeCallback: (_, val) => { irqMonth = (int)val; CheckAlarm(); }, valueProviderCallback: _ => (ulong)irqMonth, name: "MONTH")
+                .WithValueField(12, 12, writeCallback: (_, val) => { irqYear = (int)val; CheckAlarm(); }, valueProviderCallback: _ => (ulong)irqYear, name: "YEAR")
+                .WithFlag(24, writeCallback: (_, val) => { dayMatchEnabled = val; CheckAlarm(); }, valueProviderCallback: _ => dayMatchEnabled, name: "DAY_ENA")
+                .WithFlag(25, writeCallback: (_, val) => { monthMatchEnabled = val; CheckAlarm(); }, valueProviderCallback: _ => monthMatchEnabled, name: "MONTH_ENA")
+                .WithFlag(26, writeCallback: (_, val) => { yearMatchEnabled = val; CheckAlarm(); }, valueProviderCallback: _ => yearMatchEnabled, name: "YEAR_ENA")
+                .WithReservedBits(27, 1)
+                .WithFlag(28, writeCallback: (_, val) => {
+                    matchEnabled = val;
+                    matchActive = val;
+                    this.Log(LogLevel.Info, "RTC Match Enable: {0}", val);
+                    CheckAlarm();
+                }, valueProviderCallback: _ => matchEnabled, name: "MATCH_ENA")
+                .WithFlag(29, FieldMode.Read, valueProviderCallback: _ => matchActive, name: "MATCH_ACTIVE")
+                .WithReservedBits(30, 2);
+
+            Registers.IRQ_SETUP_1.Define(this)
+                .WithValueField(0, 6, writeCallback: (_, val) => { irqSec = (int)val; CheckAlarm(); }, valueProviderCallback: _ => (ulong)irqSec, name: "SEC")
+                .WithReservedBits(6, 2)
+                .WithValueField(8, 6, writeCallback: (_, val) => { irqMin = (int)val; CheckAlarm(); }, valueProviderCallback: _ => (ulong)irqMin, name: "MIN")
+                .WithReservedBits(14, 2)
+                .WithValueField(16, 5, writeCallback: (_, val) => { irqHour = (int)val; CheckAlarm(); }, valueProviderCallback: _ => (ulong)irqHour, name: "HOUR")
+                .WithReservedBits(21, 3)
+                .WithValueField(24, 3, writeCallback: (_, val) => { irqDotw = (int)val; CheckAlarm(); }, valueProviderCallback: _ => (ulong)irqDotw, name: "DOTW")
+                .WithReservedBits(27, 1)
+                .WithFlag(28, writeCallback: (_, val) => { secMatchEnabled = val; CheckAlarm(); }, valueProviderCallback: _ => secMatchEnabled, name: "SEC_ENA")
+                .WithFlag(29, writeCallback: (_, val) => { minMatchEnabled = val; CheckAlarm(); }, valueProviderCallback: _ => minMatchEnabled, name: "MIN_ENA")
+                .WithFlag(30, writeCallback: (_, val) => { hourMatchEnabled = val; CheckAlarm(); }, valueProviderCallback: _ => hourMatchEnabled, name: "HOUR_ENA")
+                .WithFlag(31, writeCallback: (_, val) => { dotwMatchEnabled = val; CheckAlarm(); }, valueProviderCallback: _ => dotwMatchEnabled, name: "DOTW_ENA");
+
+            Registers.RTC_1.Define(this)
+                .WithValueField(0, 5, FieldMode.Read, valueProviderCallback: _ => (ulong)latchedDay, name: "DAY")
+                .WithReservedBits(5, 3)
+                .WithValueField(8, 4, FieldMode.Read, valueProviderCallback: _ => (ulong)latchedMonth, name: "MONTH")
+                .WithValueField(12, 12, FieldMode.Read, valueProviderCallback: _ => (ulong)latchedYear, name: "YEAR")
+                .WithReservedBits(24, 8);
+
+            Registers.RTC_0.Define(this)
+                .WithValueField(0, 6, FieldMode.Read, valueProviderCallback: _ => {
+                    latchedYear = year;
+                    latchedMonth = month;
+                    latchedDay = day;
+                    return (ulong)second;
+                }, name: "SEC")
+                .WithReservedBits(6, 2)
+                .WithValueField(8, 6, FieldMode.Read, valueProviderCallback: _ => (ulong)minute, name: "MIN")
+                .WithReservedBits(14, 2)
+                .WithValueField(16, 5, FieldMode.Read, valueProviderCallback: _ => (ulong)hour, name: "HOUR")
+                .WithReservedBits(21, 3)
+                .WithValueField(24, 3, FieldMode.Read, valueProviderCallback: _ => (ulong)dotw, name: "DOTW")
+                .WithReservedBits(27, 5);
+
+            Registers.INTR.Define(this)
+                .WithFlag(0, FieldMode.Read, valueProviderCallback: _ => rawInterrupt, name: "RTC")
+                .WithReservedBits(1, 31);
+
+            Registers.INTE.Define(this)
+                .WithFlag(0, writeCallback: (_, val) => {
+                    interruptEnabled = val;
+                    UpdateInterrupts();
+                }, valueProviderCallback: _ => interruptEnabled, name: "RTC")
+                .WithReservedBits(1, 31);
+
+            Registers.INTF.Define(this)
+                .WithFlag(0, writeCallback: (_, val) => {
+                    interruptForce = val;
+                    UpdateInterrupts();
+                }, valueProviderCallback: _ => interruptForce, name: "RTC")
+                .WithReservedBits(1, 31);
+
+            Registers.INTS.Define(this)
+                .WithFlag(0, FieldMode.Read, valueProviderCallback: _ => (rawInterrupt || interruptForce) && interruptEnabled, name: "RTC")
+                .WithReservedBits(1, 31);
+        }
+
+        public GPIO IRQ { get; private set; }
+
+        private IValueRegisterField clkDivM1;
+        private readonly LimitTimer tickTimer;
+
+        private bool rtcEnabled;
+        private bool rtcActive;
+        private bool forceNotLeapYear;
+
+        private int year;
+        private int month;
+        private int day;
+        private int dotw;
+        private int hour;
+        private int minute;
+        private int second;
+
+        private int latchedYear;
+        private int latchedMonth;
+        private int latchedDay;
+
+        private int setupYear;
+        private int setupMonth;
+        private int setupDay;
+        private int setupDotw;
+        private int setupHour;
+        private int setupMin;
+        private int setupSec;
+
+        private bool matchActive;
+        private bool matchEnabled;
+        private bool yearMatchEnabled;
+        private bool monthMatchEnabled;
+        private bool dayMatchEnabled;
+        private bool dotwMatchEnabled;
+        private bool hourMatchEnabled;
+        private bool minMatchEnabled;
+        private bool secMatchEnabled;
+
+        private int irqYear;
+        private int irqMonth;
+        private int irqDay;
+        private int irqDotw;
+        private int irqHour;
+        private int irqMin;
+        private int irqSec;
+
+        private bool rawInterrupt;
+        private bool interruptEnabled;
+        private bool interruptForce;
+
+        private enum Registers
+        {
+            CLKDIV_M1 = 0x00,
+            SETUP_0 = 0x04,
+            SETUP_1 = 0x08,
+            CTRL = 0x0c,
+            IRQ_SETUP_0 = 0x10,
+            IRQ_SETUP_1 = 0x14,
+            RTC_1 = 0x18,
+            RTC_0 = 0x1c,
+            INTR = 0x20,
+            INTE = 0x24,
+            INTF = 0x28,
+            INTS = 0x2c
+        }
+    }
+}

--- a/test/rtc.robot
+++ b/test/rtc.robot
@@ -1,0 +1,41 @@
+*** Settings ***
+Suite Setup                   Setup
+Suite Teardown                Teardown
+Test Teardown                 Test Teardown
+Resource                      ${RENODEKEYWORDS}
+
+*** Variables ***
+${UART}                       sysbus.uart0
+${FIRMWARE}                   ${CURDIR}/../.pio/build/seeed-xiao-rp2040/firmware.elf
+${RESC}                       ${CURDIR}/renode-config/run_xiao.resc
+
+*** Test Cases ***
+Should Verify RTC Timekeeping
+    [Documentation]           Verifies that RTC can be set and increments correctly.
+    Create Machine
+    Start Emulation
+
+    Wait For Line On Uart     UART Bidirectional Communication Ready
+
+    Write Char On Uart        R
+    Wait For Line On Uart     RTC Time Set: Monday 6 May 12:00:00 2024
+    Wait For Line On Uart     RTC Time After 1s: Monday 6 May 12:00:01 2024
+
+Should Verify RTC Alarm
+    [Documentation]           Verifies that RTC alarm interrupt fires after 2 seconds.
+    Create Machine
+    Start Emulation
+
+    Wait For Line On Uart     UART Bidirectional Communication Ready
+
+    Write Char On Uart        Q
+    Wait For Line On Uart     Setting RTC Alarm...
+    Wait For Line On Uart     RTC Alarm Set for +2s
+    # Wait for the alarm to fire (2 seconds simulated time)
+    Wait For Line On Uart     RTC Alarm Handled  timeout=5
+
+*** Keywords ***
+Create Machine
+    Execute Command           $global.TEST_FILE = @${FIRMWARE}
+    Execute Command           include @${RESC}
+    Create Terminal Tester    ${UART}


### PR DESCRIPTION
Implemented the Real-Time Clock (RTC) peripheral for the RP2040 in the Renode emulation environment and added corresponding firmware support.

### Changes:
- **Renode Model**: Added `test/renode-config/emulation/peripherals/rtc/rp2040_rtc.cs` which implements the RTC registers and logic according to the RP2040 datasheet, including:
    - 1Hz timekeeping with year, month, day, dotw, hour, minute, second.
    - Simplified leap year logic (divisible by 4).
    - Alarm matching on any combination of datetime fields.
    - Register latching mechanism (reading RTC_0 latches RTC_1).
- **Platform Integration**: Updated `rp2040.repl` and `initialize_peripherals_source.resc` to instantiate and connect the RTC peripheral.
- **Firmware**: Updated `src/main.cpp` to include:
    - `rtc_init()` call in `setup()`.
    - Command 'R' to set a specific date/time and verify it increments.
    - Command 'Q' to set an RTC alarm and verify the interrupt fires.
- **Verification**: Added `test/rtc.robot` which passes both timekeeping and alarm test cases. Verified that the existing `full_suite.robot` also passes.
- **Documentation**: Updated `ROADMAP.md` to reflect the completion of RTC support.

Fixes #122

---
*PR created automatically by Jules for task [17196527258513062341](https://jules.google.com/task/17196527258513062341) started by @chatelao*