### PR TITLE
SPI External Flash Support and Verification

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -90,9 +90,9 @@ The final plan to implement the `CONCEPT.md` and `DESIGN.md` to achieve the top 
 
 ## Phase 9: SPI Peripheral Support
 - [x] Implement SPI loopback test in firmware and verify in Renode [2026-05-04]
-- [ ] Configure SPI pins and an external SPI device in Renode `.repl`
-- [ ] Implement SPI device communication in firmware (e.g., reading WHO_AM_I)
-- [ ] Create Robot Framework tests for SPI bidirectional data transfer
+- [x] Configure SPI pins and an external SPI device in Renode `.repl` [2026-05-07]
+- [x] Implement SPI device communication in firmware (e.g., reading WHO_AM_I) [2026-05-07]
+- [x] Create Robot Framework tests for SPI bidirectional data transfer [2026-05-07]
 
 ## Phase 11: PIO Integration
 - [x] Draft `docs/PIO_CONCEPT.md` for PIO integration [2026-05-03]

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -201,9 +201,8 @@ void loop() {
       SPI.begin();
 
       // Manually enable loopback mode in the SPI0 peripheral (PL022)
-      // Using SET alias (base + 0x2000) for safety
-      volatile uint32_t *spi0_cr1_set = (volatile uint32_t *)(0x4003c000 + 0x2000 + 0x4);
-      *spi0_cr1_set = 0x1;
+      volatile uint32_t *spi0_cr1 = (volatile uint32_t *)(0x4003c000 + 0x4);
+      *spi0_cr1 |= 0x1;
 
       uint8_t testByte = 0xBC;
       uint8_t receivedByte = SPI.transfer(testByte);
@@ -367,6 +366,12 @@ void loop() {
       Serial1.flush();
     } else if (incomingByte == 'J') {
       // External SPI Flash Test (JEDEC ID)
+      // Hardware SPI0 pins on Seeed XIAO RP2040
+      gpio_set_function(2, GPIO_FUNC_SPI); // SCK
+      gpio_set_function(3, GPIO_FUNC_SPI); // TX (MOSI)
+      gpio_set_function(4, GPIO_FUNC_SPI); // RX (MISO)
+      gpio_set_function(1, GPIO_FUNC_SPI); // CS
+
       SPI.setSCK(2);
       SPI.setTX(3);
       SPI.setRX(4);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -201,10 +201,9 @@ void loop() {
       SPI.begin();
 
       // Manually enable loopback mode in the SPI0 peripheral (PL022)
-      // SSPCR1 (0x4) bit 0 is LBM (Loop Back Mode)
-      // On RP2040, SPI0 base is 0x4003c000
-      volatile uint32_t *spi0_cr1 = (volatile uint32_t *)(0x4003c000 + 0x4);
-      *spi0_cr1 |= 0x1;
+      // Using SET alias (base + 0x2000) for safety
+      volatile uint32_t *spi0_cr1_set = (volatile uint32_t *)(0x4003c000 + 0x2000 + 0x4);
+      *spi0_cr1_set = 0x1;
 
       uint8_t testByte = 0xBC;
       uint8_t receivedByte = SPI.transfer(testByte);
@@ -218,6 +217,9 @@ void loop() {
         Serial1.print(", Got 0x");
         Serial1.println(receivedByte, HEX);
       }
+      // Disable loopback using CLEAR alias (base + 0x3000)
+      volatile uint32_t *spi0_cr1_clr = (volatile uint32_t *)(0x4003c000 + 0x3000 + 0x4);
+      *spi0_cr1_clr = 0x1;
       SPI.end();
       Serial1.flush();
     } else if (incomingByte == 'E') {
@@ -370,6 +372,10 @@ void loop() {
       SPI.setRX(4);
       SPI.setCS(1);
       SPI.begin();
+
+      // Ensure loopback is OFF using CLEAR alias
+      volatile uint32_t *spi0_cr1_clr = (volatile uint32_t *)(0x4003c000 + 0x3000 + 0x4);
+      *spi0_cr1_clr = 0x1;
 
       // JEDEC ID command is 0x9F
       // We expect 3 bytes: Manufacturer ID (0xEF), Memory Type, Capacity

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -363,6 +363,34 @@ void loop() {
       rtc_set_alarm(&alarm, on_rtc_interrupt);
       Serial1.println("RTC Alarm Set for +2s");
       Serial1.flush();
+    } else if (incomingByte == 'J') {
+      // External SPI Flash Test (JEDEC ID)
+      SPI.setSCK(2);
+      SPI.setTX(3);
+      SPI.setRX(4);
+      SPI.setCS(1);
+      SPI.begin();
+
+      // JEDEC ID command is 0x9F
+      // We expect 3 bytes: Manufacturer ID (0xEF), Memory Type, Capacity
+
+      SPI.transfer(0x9F);
+      uint8_t m_id = SPI.transfer(0x00);
+      uint8_t type = SPI.transfer(0x00);
+      uint8_t cap = SPI.transfer(0x00);
+
+      Serial1.print("Flash JEDEC ID: ");
+      if (m_id < 0x10) Serial1.print("0");
+      Serial1.print(m_id, HEX);
+      Serial1.print(" ");
+      if (type < 0x10) Serial1.print("0");
+      Serial1.print(type, HEX);
+      Serial1.print(" ");
+      if (cap < 0x10) Serial1.print("0");
+      Serial1.println(cap, HEX);
+
+      SPI.end();
+      Serial1.flush();
     } else if (incomingByte == 'D') {
       // DMA Memory-to-Memory Test
       const char *src_str = "DMA TRANSFER TEST";

--- a/test/full_suite.robot
+++ b/test/full_suite.robot
@@ -51,6 +51,10 @@ Should Pass Full Test Suite
     Write Char On Uart        S
     Wait For Line On Uart     SPI Loopback Success: 0xBC
 
+    # 8.1. SPI External Flash (JEDEC ID)
+    Write Char On Uart        J
+    Wait For Line On Uart     Flash JEDEC ID: EF 40 15
+
     # 9. Timer Alarms
     # One-shot
     Write Char On Uart        T

--- a/test/renode-config/boards/seeed_xiao_rp2040.repl
+++ b/test/renode-config/boards/seeed_xiao_rp2040.repl
@@ -34,3 +34,6 @@ external_flash: SPI.W25QXX @ spi0
 
 gpio:
     1 -> external_flash@0
+    2 -> external_flash@1
+    3 -> external_flash@2
+    4 -> external_flash@3

--- a/test/renode-config/boards/seeed_xiao_rp2040.repl
+++ b/test/renode-config/boards/seeed_xiao_rp2040.repl
@@ -27,7 +27,10 @@ pwm:
 bmp280: I2C.BMP280 @ i2c1 0x76
 
 external_flash_mem: Memory.MappedMemory @ sysbus 0x11000000
-    size: 0x100000
+    size: 0x200000
 
 external_flash: SPI.W25QXX @ spi0
     underlyingMemory: external_flash_mem
+
+gpio:
+    1 -> external_flash@0

--- a/test/renode-config/boards/seeed_xiao_rp2040.repl
+++ b/test/renode-config/boards/seeed_xiao_rp2040.repl
@@ -25,3 +25,9 @@ pwm:
     12 -> gpio@12 // PWM6_A
 
 bmp280: I2C.BMP280 @ i2c1 0x76
+
+external_flash_mem: Memory.MappedMemory @ sysbus 0x11000000
+    size: 0x100000
+
+external_flash: SPI.W25QXX @ spi0
+    underlyingMemory: external_flash_mem

--- a/test/renode-config/emulation/peripherals/spi/rp2040_spi.cs
+++ b/test/renode-config/emulation/peripherals/spi/rp2040_spi.cs
@@ -272,7 +272,18 @@ namespace Antmicro.Renode.Peripherals.SPI
         }
         else
         {
-          receiveData = (ushort)((receiveData << 1) | Convert.ToUInt16(ReadMultiplePins(rxPins)));
+          bool bitToReceive = ReadMultiplePins(rxPins);
+          if (transmitCounter == 0)
+          {
+            externalResponse = 0;
+            if (RegisteredPeripheral != null)
+            {
+              externalResponse = RegisteredPeripheral.Transmit((byte)transmitData);
+              this.Log(LogLevel.Noisy, "SPI{0}: Sent byte 0x{1:X2} to external peripheral, got 0x{2:X2}", id, (byte)transmitData, externalResponse);
+            }
+          }
+          bool externalBit = Convert.ToBoolean((externalResponse >> (7 - (transmitCounter % 8))) & 1);
+          receiveData = (ushort)((receiveData << 1) | Convert.ToUInt16(externalBit | bitToReceive));
         }
         transmitCounter += 1;
       }
@@ -345,7 +356,10 @@ namespace Antmicro.Renode.Peripherals.SPI
         .WithFlag(0, valueProviderCallback: _ => loopbackMode,
           writeCallback: (_, value) => loopbackMode = value, name: "SSPCR1_LBM")
         .WithFlag(1, valueProviderCallback: _ => synchronousSerialPort,
-          writeCallback: (_, value) => synchronousSerialPort = value, name: "SSPCR1_SSE")
+          writeCallback: (_, value) => {
+            synchronousSerialPort = value;
+            SetMultiplePins(csPins, !value);
+          }, name: "SSPCR1_SSE")
         .WithFlag(2, valueProviderCallback: _ => masterSlaveSelect,
           writeCallback: (_, value) => masterSlaveSelect = value, name: "SSPCR1_MS")
         .WithFlag(3, valueProviderCallback: _ => slaveModeDisabled,
@@ -453,6 +467,7 @@ namespace Antmicro.Renode.Peripherals.SPI
     private byte transmitCounter;
     private ushort transmitData;
     private ushort receiveData;
+    private byte externalResponse;
     private enum Registers
     {
       SSPCR0 = 0x0,

--- a/test/renode-config/emulation/peripherals/spi/rp2040_spi.cs
+++ b/test/renode-config/emulation/peripherals/spi/rp2040_spi.cs
@@ -195,7 +195,7 @@ namespace Antmicro.Renode.Peripherals.SPI
     {
       foreach (int pin in pins)
       {
-        this.gpio.WritePin(pin, state);
+        this.gpio.WritePin(pin, state, (id == 0) ? RP2040GPIO.GpioFunction.SPI0_CSN : RP2040GPIO.GpioFunction.SPI1_CSN, true);
       }
     }
 
@@ -241,6 +241,7 @@ namespace Antmicro.Renode.Peripherals.SPI
         else
         {
           transmitData = 0;
+          transmitCounter = 16;
 
           SetMultiplePins(txPins, false);
           SetMultiplePins(clockPins, false);
@@ -279,7 +280,7 @@ namespace Antmicro.Renode.Peripherals.SPI
             if (RegisteredPeripheral != null)
             {
               externalResponse = RegisteredPeripheral.Transmit((byte)transmitData);
-              this.Log(LogLevel.Noisy, "SPI{0}: Sent byte 0x{1:X2} to external peripheral, got 0x{2:X2}", id, (byte)transmitData, externalResponse);
+              this.Log(LogLevel.Debug, "SPI{0}: Sent byte 0x{1:X2} to external peripheral, got 0x{2:X2}", id, (byte)transmitData, externalResponse);
             }
           }
           bool externalBit = Convert.ToBoolean((externalResponse >> (7 - (transmitCounter % 8))) & 1);
@@ -354,7 +355,10 @@ namespace Antmicro.Renode.Peripherals.SPI
 
       Registers.SSPCR1.Define(registers)
         .WithFlag(0, valueProviderCallback: _ => loopbackMode,
-          writeCallback: (_, value) => loopbackMode = value, name: "SSPCR1_LBM")
+          writeCallback: (_, value) => {
+            loopbackMode = value;
+            this.Log(LogLevel.Debug, "SPI{0}: Loopback Mode set to {1}", id, value);
+          }, name: "SSPCR1_LBM")
         .WithFlag(1, valueProviderCallback: _ => synchronousSerialPort,
           writeCallback: (_, value) => {
             synchronousSerialPort = value;

--- a/test/renode-config/emulation/peripherals/spi/rp2040_spi.cs
+++ b/test/renode-config/emulation/peripherals/spi/rp2040_spi.cs
@@ -284,7 +284,7 @@ namespace Antmicro.Renode.Peripherals.SPI
             }
           }
           bool externalBit = Convert.ToBoolean((externalResponse >> (7 - (transmitCounter % 8))) & 1);
-          receiveData = (ushort)((receiveData << 1) | Convert.ToUInt16(externalBit | bitToReceive));
+          receiveData = (ushort)((receiveData << 1) | Convert.ToUInt16(RegisteredPeripheral != null ? externalBit : bitToReceive));
         }
         transmitCounter += 1;
       }


### PR DESCRIPTION
This change implements support for external SPI devices in the Renode simulation for the Seeed XIAO RP2040. Key enhancements include:
1.  **Hardware Modeling**: Patched the `rp2040_spi.cs` emulator to transmit bits to external peripherals and automatically drive CS lines when the SPI controller is enabled.
2.  **Board Configuration**: Added a `W25QXX` flash chip and dedicated memory to `seeed_xiao_rp2040.repl`.
3.  **Firmware**: Implemented a JEDEC ID retrieval command ('J') using the Arduino SPI library.
4.  **Verification**: Expanded `full_suite.robot` with a test case for external SPI communication and updated `ROADMAP.md` to reflect Phase 9 completion.

Fixes #130

---
*PR created automatically by Jules for task [10566879030991721967](https://jules.google.com/task/10566879030991721967) started by @chatelao*