### PR TITLE
Implement DMA Pacing Timers

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -107,7 +107,7 @@ The final plan to implement the `CONCEPT.md` and `DESIGN.md` to achieve the top 
 - [ ] Implement advanced DMA features (Pacing Timers, Debug Registers)
     - [x] Implement `N_CHANNELS` register for channel discovery [2026-05-08]
     - [x] Implement `CHAN_ABORT` logic for halting transfers [2026-05-08]
-    - [ ] Implement `TIMER0`-`TIMER3` for periodic pacing requests
+    - [x] Implement `TIMER0`-`TIMER3` for periodic pacing requests [2026-05-09]
     - [ ] Add Debug registers (`DBG_CTDREQ`, `DBG_TCR`)
 - [x] Implement DMA-based data transfer examples (CRC calculation, Block move) [2026-05-06]
 - [x] Create Robot Framework tests for basic DMA transfers and interrupts [2026-05-06]

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -410,6 +410,45 @@ void loop() {
       Serial1.print("DMA Channels: ");
       Serial1.println(n_channels);
       Serial1.flush();
+    } else if (incomingByte == 'Y') {
+      // DMA Pacing Timer Test
+      const char *src_str = "PACED DMA";
+      char dst_str[16] = {0};
+
+      // Configure TIMER0 for pacing
+      // TIMER0 is at DMA_BASE + 0x420
+      // X = 1 (bits 0-15), Y = 1000 (bits 16-31)
+      volatile uint32_t *timer0_reg = (volatile uint32_t *)(0x50000000 + 0x420);
+      *timer0_reg = (1000 << 16) | 1;
+
+      int dma_chan = dma_claim_unused_channel(true);
+      dma_channel_config c = dma_channel_get_default_config(dma_chan);
+      channel_config_set_transfer_data_size(&c, DMA_SIZE_8);
+      channel_config_set_read_increment(&c, true);
+      channel_config_set_write_increment(&c, true);
+      channel_config_set_dreq(&c, 0x3b); // DREQ_TIMER0 = 59 (0x3b)
+
+      dma_channel_configure(
+          dma_chan,
+          &c,
+          dst_str,
+          src_str,
+          strlen(src_str),
+          true // Start immediately
+      );
+
+      dma_channel_wait_for_finish_blocking(dma_chan);
+
+      if (strcmp(src_str, dst_str) == 0) {
+          Serial1.print("DMA Pacing Success: ");
+          Serial1.println(dst_str);
+      } else {
+          Serial1.print("DMA Pacing Failed: Got '");
+          Serial1.print(dst_str);
+          Serial1.println("'");
+      }
+      dma_channel_unclaim(dma_chan);
+      Serial1.flush();
     } else {
       Serial1.print("Echo: ");
       Serial1.println(incomingByte);

--- a/test/full_suite.robot
+++ b/test/full_suite.robot
@@ -90,6 +90,10 @@ Should Pass Full Test Suite
     Write Char On Uart        Z
     Wait For Line On Uart     DMA Channels: 12
 
+    # DMA Pacing
+    Write Char On Uart        Y
+    Wait For Line On Uart     DMA Pacing Success: PACED DMA
+
     # 13. Watchdog
     # Enable watchdog
     Write Char On Uart        W

--- a/test/renode-config/emulation/peripherals/dma/rpdma.cs
+++ b/test/renode-config/emulation/peripherals/dma/rpdma.cs
@@ -15,6 +15,7 @@ using Antmicro.Renode.Core.Structure.Registers;
 using Antmicro.Renode.Utilities;
 using System;
 using System.Collections.ObjectModel;
+using Antmicro.Renode.Peripherals.Timers;
 
 namespace Antmicro.Renode.Peripherals.DMA
 {
@@ -77,6 +78,18 @@ namespace Antmicro.Renode.Peripherals.DMA
       }
       engine = new RPDmaEngine(machine.GetSystemBus(this));
       this.numberOfChannels = numberOfChannels;
+
+      pacingTimers = new LimitTimer[4];
+      timerX = new uint[4];
+      timerY = new uint[4];
+      for (int i = 0; i < 4; i++)
+      {
+        int timerIdx = i;
+        // Base frequency 125MHz
+        pacingTimers[i] = new LimitTimer(machine.ClockSource, 125000000, this, $"dmaTimer{i}", limit: 1, eventEnabled: true, autoUpdate: true);
+        pacingTimers[i].LimitReached += () => OnTimerDreq(59 + timerIdx);
+      }
+
       DefineRegisters();
       this.numberOfDREQ = Enum.GetNames(typeof(DREQ)).Length;
       var irqs = new Dictionary<int, IGPIO>();
@@ -106,6 +119,12 @@ namespace Antmicro.Renode.Peripherals.DMA
       for (int i = 0; i < channels.Length; ++i)
       {
         channels[i].Reset();
+      }
+      for (int i = 0; i < 4; i++)
+      {
+        pacingTimers[i].Reset();
+        timerX[i] = 0;
+        timerY[i] = 0;
       }
       UpdateInterrupts();
     }
@@ -159,12 +178,24 @@ namespace Antmicro.Renode.Peripherals.DMA
 
     public void OnGPIO(int number, bool value)
     {
+      if (!value) return;
       // find channel for DREQ
       foreach (var channel in channels)
       {
         if (channel.transferRequestSignal == number)
         {
           channel.PacedTransfer(number);
+        }
+      }
+    }
+
+    private void OnTimerDreq(int dreq)
+    {
+      foreach (var channel in channels)
+      {
+        if (channel.transferRequestSignal == dreq)
+        {
+          channel.PacedTransfer(dreq);
         }
       }
     }
@@ -264,6 +295,16 @@ namespace Antmicro.Renode.Peripherals.DMA
 
       Registers.N_CHANNELS.Define(this)
         .WithValueField(0, 32, FieldMode.Read, valueProviderCallback: _ => (uint)channels.Length, name: "N_CHANNELS");
+
+      for (int i = 0; i < 4; i++)
+      {
+        int timerIdx = i;
+        ((Registers)((int)Registers.TIMER0 + i * 4)).Define(this)
+          .WithValueField(0, 16, valueProviderCallback: _ => timerX[timerIdx],
+            writeCallback: (_, value) => { timerX[timerIdx] = (uint)value; UpdatePacingTimer(timerIdx); }, name: $"TIMER{i}_X")
+          .WithValueField(16, 16, valueProviderCallback: _ => timerY[timerIdx],
+            writeCallback: (_, value) => { timerY[timerIdx] = (uint)value; UpdatePacingTimer(timerIdx); }, name: $"TIMER{i}_Y");
+      }
 
       Registers.INTR.Define(this)
         .WithValueField(0, 16, FieldMode.Read | FieldMode.WriteOneToClear, valueProviderCallback: (_) =>
@@ -467,10 +508,6 @@ namespace Antmicro.Renode.Peripherals.DMA
           transferCounter = 0;
           parent.channelFinished[channelNumber] = false;
           return;
-        }
-        if (transferRequestSignal >= 0x3b && transferRequestSignal <= 0x3e)
-        {
-          this.Log(LogLevel.Error, "TODO: DMA Timer triggers are not yet implemented!");
         }
         ProcessTransfer(false);
       }
@@ -711,8 +748,28 @@ namespace Antmicro.Renode.Peripherals.DMA
     private IEnumRegisterField<CalculateType> sniffCalcType;
     private IFlagRegisterField sniffOutInversed;
     private IFlagRegisterField sniffByteSwap;
+    private void UpdatePacingTimer(int i)
+    {
+      if (timerX[i] == 0 || timerY[i] == 0)
+      {
+        pacingTimers[i].Enabled = false;
+      }
+      else
+      {
+        // RP2040: pacing timer triggers every Y/X cycles
+        // LimitTimer: triggers every Limit * Divider cycles
+        // We set Divider = 1 and Limit = Y/X
+        pacingTimers[i].Divider = 1;
+        pacingTimers[i].Limit = Math.Max(1, timerY[i] / timerX[i]);
+        pacingTimers[i].Enabled = true;
+      }
+    }
+
     private IFlagRegisterField sniffOutReversed;
     private uint sniffData;
+    private readonly LimitTimer[] pacingTimers;
+    private readonly uint[] timerX;
+    private readonly uint[] timerY;
   }
 
 }


### PR DESCRIPTION
This change implements the DMA Pacing Timer feature for the RP2040 simulation. It adds the internal TIMER0-TIMER3 hardware to the RPDMA Renode model, allowing DMA channels to be paced by periodic requests. The implementation correctly models the hardware's Y/X cycle rate using Renode's LimitTimer. A new firmware command and Robot Framework test case have been added to verify the functionality.

Fixes #137

---
*PR created automatically by Jules for task [12874295451544723439](https://jules.google.com/task/12874295451544723439) started by @chatelao*