### PR TITLE
Implement Phase 13: Full PWM Feature Support

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -117,10 +117,10 @@ The final plan to implement the `CONCEPT.md` and `DESIGN.md` to achieve the top 
 ## Phase 13: Full PWM Feature Support
 - [x] Implement 16-bit dynamic counter in `RP2040PWM` Renode model [2026-05-06]
 - [x] Implement double buffering for `CC` and `TOP` registers (latched update on wrap) [2026-05-06]
-- [ ] Implement `DIVMODE` support for LEVEL, RISE, and FALL input modes
-- [x] Implement IRQ and DREQ signal assertion on counter wrap [2026-05-06]
-- [ ] Implement `PH_ADV` and `PH_RET` phase adjustment logic
-- [x] Create Robot Framework tests for advanced PWM features (interrupts, inputs) [2026-05-06]
+- [x] Implement `DIVMODE` support for LEVEL, RISE, and FALL input modes [2026-05-09]
+- [x] Implement IRQ and DREQ signal assertion on counter wrap [2026-05-09]
+- [x] Implement `PH_ADV` and `PH_RET` phase adjustment logic [2026-05-09]
+- [x] Create Robot Framework tests for advanced PWM features (interrupts, inputs) [2026-05-09]
 
 ## Phase 14: Full ADC Feature Support
 - [x] Fix round-robin logic in `RP2040ADC` to correctly cycle through enabled channels [2026-05-04]

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -449,8 +449,35 @@ void loop() {
       }
       dma_channel_unclaim(dma_chan);
       Serial1.flush();
+    } else if (incomingByte == 'J') {
+      // PWM DIVMODE Test (RISE mode)
+      uint slice_num = pwm_gpio_to_slice_num(LED_PIN);
+      pwm_set_enabled(slice_num, false);
+      pwm_config config = pwm_get_default_config();
+      pwm_config_set_clkdiv(&config, 1.0f);
+      pwm_config_set_wrap(&config, 100);
+      pwm_config_set_clkdiv_mode(&config, PWM_DIV_B_RISING);
+      pwm_init(slice_num, &config, false);
+      pwm_set_counter(slice_num, 0);
+      pwm_set_enabled(slice_num, true);
+      Serial1.println("PWM RISE Mode Enabled");
+      Serial1.flush();
+    } else if (incomingByte == 'N') {
+      // Read PWM Counter
+      uint slice_num = pwm_gpio_to_slice_num(LED_PIN);
+      Serial1.printf("PWM CTR: %u\n", (unsigned int)pwm_get_counter(slice_num));
+      Serial1.flush();
+    } else if (incomingByte == 'L') {
+      // PWM Phase Adjustment Test
+      uint slice_num = pwm_gpio_to_slice_num(LED_PIN);
+      pwm_set_enabled(slice_num, false);
+      pwm_set_counter(slice_num, 0);
+      pwm_set_enabled(slice_num, true);
+      // Bit 7 is PH_ADV
+      pwm_hw->slice[slice_num].csr |= (1u << 7); // PH_ADV
+      Serial1.println("PWM Phase Advanced");
+      Serial1.flush();
     } else if (incomingByte == 'O') {
-      // DMA Debug Register Test
       uint32_t src = 0x12345678;
       uint32_t dst = 0;
       int dma_chan = dma_claim_unused_channel(true);

--- a/test/full_suite.robot
+++ b/test/full_suite.robot
@@ -81,7 +81,39 @@ Should Pass Full Test Suite
     Wait For Line On Uart     PWM Interrupt Handled
     Wait For Line On Uart     PWM Interrupt Handled
 
-    # 12. DMA
+    # 12. PWM RISE Mode and Counter
+    Write Char On Uart        J
+    Wait For Line On Uart     PWM RISE Mode Enabled
+    Write Char On Uart        N
+    Wait For Line On Uart     PWM CTR: 0
+    # PWM Slice 0 (LED_PIN 17) B input is GPIO 1
+    # On RP2040, slice = pin >> 1. 17 >> 1 = 8? Wait.
+    # RP2040 has 8 slices (0-7). Slice 0 is GPIO 0,1. Slice 1 is GPIO 2,3...
+    # LED_PIN 17 is Slice 0? No, 17/2 = 8, but it wraps.
+    # 17 % 16 = 1. 1 >> 1 = 0. So GPIO 16,17 is Slice 0.
+    # Input for Slice 0 is GPIO 1 (A) or 1? No.
+    # GPIO 0,1 -> Slice 0
+    # GPIO 16,17 -> Slice 0
+    # For Slice 0, B input is GPIO 1 or GPIO 17.
+    # If we use LED_PIN 17, it is B pin of Slice 0.
+    # Wait, the C# model uses NumberOfSlices = 8.
+    # We added ExternalTrigger(slice, value) to be sure.
+    Execute Command           sysbus.pwm ExternalTrigger 0 true
+    Execute Command           sysbus.pwm ExternalTrigger 0 false
+    Write Char On Uart        N
+    Wait For Line On Uart     PWM CTR: 1
+    Execute Command           sysbus.pwm ExternalTrigger 0 true
+    Execute Command           sysbus.pwm ExternalTrigger 0 false
+    Write Char On Uart        N
+    Wait For Line On Uart     PWM CTR: 2
+
+    # 13. PWM Phase Adjustment
+    Write Char On Uart        L
+    Wait For Line On Uart     PWM Phase Advanced
+    Write Char On Uart        N
+    Wait For Line On Uart     PWM CTR: 1
+
+    # 14. DMA
     Write Char On Uart        D
     Wait For Line On Uart     DMA Transfer Success: DMA TRANSFER TEST  timeout=60
     Wait For Line On Uart     DMA Interrupt Handled  timeout=60

--- a/test/renode-config/cores/rp2040.repl
+++ b/test/renode-config/cores/rp2040.repl
@@ -245,3 +245,11 @@ pwm: PWM.RP2040PWM @ sysbus 0x40050000 {
 
 pwm:
     IRQ -> nvic0@4
+    24 -> dma@24
+    25 -> dma@25
+    26 -> dma@26
+    27 -> dma@27
+    28 -> dma@28
+    29 -> dma@29
+    30 -> dma@30
+    31 -> dma@31

--- a/test/renode-config/emulation/peripherals/pwm/rp2040_pwm.cs
+++ b/test/renode-config/emulation/peripherals/pwm/rp2040_pwm.cs
@@ -18,7 +18,7 @@ using Antmicro.Renode.Peripherals.Timers;
 
 namespace Antmicro.Renode.Peripherals.PWM
 {
-    public class RP2040PWM : RP2040PeripheralBase, INumberedGPIOOutput
+    public class RP2040PWM : RP2040PeripheralBase, INumberedGPIOOutput, IGPIOReceiver
     {
         public RP2040PWM(IMachine machine, ulong address) : base(machine, address)
         {
@@ -30,6 +30,13 @@ namespace Antmicro.Renode.Peripherals.PWM
                 PWMOut[i] = new GPIO();
                 innerConnections[i] = PWMOut[i];
             }
+
+            // DREQs 24-31
+            for (int i = 0; i < NumberOfSlices; i++)
+            {
+                innerConnections[24 + i] = new GPIO();
+            }
+
             Connections = innerConnections;
 
             slices = new PWMSlice[NumberOfSlices];
@@ -54,9 +61,9 @@ namespace Antmicro.Renode.Peripherals.PWM
                    .WithFlag(1, out slices[index].phaseCorrect, name: $"CH{index}_CSR_PH_CORRECT", writeCallback: (_, __) => slices[index].Update())
                    .WithFlag(2, out slices[index].invertA, name: $"CH{index}_CSR_A_INV", writeCallback: (_, __) => slices[index].Update())
                    .WithFlag(3, out slices[index].invertB, name: $"CH{index}_CSR_B_INV", writeCallback: (_, __) => slices[index].Update())
-                   .WithValueField(4, 2, out slices[index].divMode, name: $"CH{index}_CSR_DIVMODE")
-                   .WithFlag(6, name: $"CH{index}_CSR_TOP_SEL")
-                   .WithFlag(7, name: $"CH{index}_CSR_ADVANCE")
+                   .WithValueField(4, 2, out slices[index].divMode, name: $"CH{index}_CSR_DIVMODE", writeCallback: (_, __) => slices[index].Update())
+                   .WithFlag(6, FieldMode.Write, name: $"CH{index}_CSR_PH_RET", writeCallback: (_, val) => { if(val) slices[index].RetardPhase(); })
+                   .WithFlag(7, FieldMode.Write, name: $"CH{index}_CSR_PH_ADV", writeCallback: (_, val) => { if(val) slices[index].AdvancePhase(); })
                    .WithReservedBits(8, 24);
             }, stepInBytes: 0x14);
 
@@ -145,6 +152,35 @@ namespace Antmicro.Renode.Peripherals.PWM
             UpdateInterrupts();
         }
 
+        public void SendDreq(int slice)
+        {
+            IGPIO dreq;
+            if (Connections.TryGetValue(24 + slice, out dreq))
+            {
+                dreq.Set(true);
+                dreq.Set(false);
+            }
+        }
+
+        public void ExternalTrigger(int slice, bool value)
+        {
+            if (slice < 0 || slice >= NumberOfSlices) return;
+            this.Log(LogLevel.Info, "ExternalTrigger: slice={0}, value={1}", slice, value);
+            slices[slice].OnInput(value);
+        }
+
+        public void OnGPIO(int number, bool value)
+        {
+            // We'll treat the signal number as the slice index.
+            if (number < 0 || number >= NumberOfSlices)
+            {
+                this.Log(LogLevel.Error, "Received GPIO signal on unsupported input {0}", number);
+                return;
+            }
+            this.Log(LogLevel.Info, "OnGPIO: number={0}, value={1}", number, value);
+            slices[number].OnInput(value);
+        }
+
         private void UpdateInterrupts()
         {
             bool status = ((interruptsRaw.Value | interruptsForce.Value) & interruptsEnabled.Value) != 0;
@@ -174,10 +210,7 @@ namespace Antmicro.Renode.Peripherals.PWM
                 this.index = index;
                 // We use a 2GHz internal frequency (125MHz * 16) to handle fractional dividers
                 timer = new LimitTimer(parent.machine.ClockSource, 2000000000, parent, $"pwm{index}", limit: 0xFFFF, eventEnabled: true, autoUpdate: true);
-                timer.LimitReached += () => {
-                    Latch();
-                    parent.SetInterrupt(index);
-                };
+                timer.LimitReached += OnWrap;
             }
 
             public void Reset()
@@ -186,6 +219,7 @@ namespace Antmicro.Renode.Peripherals.PWM
                 activeCompareA = 0;
                 activeCompareB = 0;
                 activeTop = 0xFFFF;
+                lastInputState = false;
                 Update();
             }
 
@@ -200,8 +234,71 @@ namespace Antmicro.Renode.Peripherals.PWM
                 activeCompareA = (uint)shadowCompareA.Value;
                 activeCompareB = (uint)shadowCompareB.Value;
                 activeTop = (uint)shadowTop.Value;
-                parent.Log(LogLevel.Noisy, "PWM Slice {0}: Latched CC=0x{1:X8}, TOP=0x{2:X4}", index, (activeCompareB << 16) | activeCompareA, activeTop);
+                parent.Log(LogLevel.Info, "PWM Slice {0}: Latched CC=0x{1:X8}, TOP=0x{2:X4}", index, (activeCompareB << 16) | activeCompareA, activeTop);
                 Update();
+            }
+
+            public void AdvancePhase()
+            {
+                parent.Log(LogLevel.Info, "PWM Slice {0}: AdvancePhase. Enabled={1}", index, enabled.Value);
+                if (!enabled.Value) return;
+                IncrementCounter();
+            }
+
+            public void RetardPhase()
+            {
+                parent.Log(LogLevel.Info, "PWM Slice {0}: RetardPhase. Enabled={1}", index, enabled.Value);
+                if (!enabled.Value) return;
+                if (timer.Value > 0)
+                {
+                    timer.Value--;
+                }
+                else
+                {
+                    timer.Value = (ulong)activeTop;
+                }
+                parent.Log(LogLevel.Info, "PWM Slice {0}: RetardPhase. New Value={1}", index, timer.Value);
+            }
+
+            public void OnInput(bool value)
+            {
+                bool oldState = lastInputState;
+                lastInputState = value;
+
+                parent.Log(LogLevel.Info, "PWM Slice {0}: OnInput({1}). OldState={2}, Enabled={3}, DivMode={4}", index, value, oldState, enabled.Value, divMode.Value);
+
+                if (!enabled.Value) return;
+
+                switch ((uint)divMode.Value)
+                {
+                    case 1: // LEVEL
+                        timer.Enabled = value;
+                        break;
+                    case 2: // RISE
+                        if (value && !oldState) IncrementCounter();
+                        break;
+                    case 3: // FALL
+                        if (!value && oldState) IncrementCounter();
+                        break;
+                }
+            }
+
+            private void IncrementCounter()
+            {
+                var newValue = (timer.Value + 1) % ((ulong)activeTop + 1);
+                timer.Value = newValue;
+                if (newValue == 0)
+                {
+                    OnWrap();
+                }
+                parent.Log(LogLevel.Info, "PWM Slice {0}: IncrementCounter. New Value={1}", index, timer.Value);
+            }
+
+            private void OnWrap()
+            {
+                Latch();
+                parent.SetInterrupt(index);
+                parent.SendDreq(index);
             }
 
             public void Update()
@@ -214,15 +311,29 @@ namespace Antmicro.Renode.Peripherals.PWM
                     return;
                 }
 
+                uint mode = (uint)divMode.Value;
+                parent.Log(LogLevel.Info, "PWM Slice {0}: Updating. Mode={1}, Enabled={2}, TOP={3}", index, mode, enabled.Value, activeTop);
+                if (mode == 0) // FREE RUNNING
+                {
+                    timer.Enabled = true;
+                }
+                else if (mode == 1) // LEVEL
+                {
+                    timer.Enabled = lastInputState;
+                }
+                else // RISE or FALL
+                {
+                    timer.Enabled = false; // Manual increment in OnInput
+                }
+
                 uint divider = (uint)(divInt.Value * 16 + divFrac.Value);
                 if (divider == 0) divider = 16; // Minimum divider is 1.0 (16/16)
 
                 // The error was: Cannot implicitly convert type 'int' to 'ulong' for timer.Divider
                 timer.Divider = (ulong)divider;
-                timer.Limit = (ulong)activeTop;
-                timer.Enabled = true;
+                timer.Limit = (ulong)activeTop + 1;
 
-                double topVal = activeTop + 1;
+                double topVal = (double)activeTop + 1;
                 double dcA = (double)activeCompareA / topVal;
                 double dcB = (double)activeCompareB / topVal;
 
@@ -245,8 +356,16 @@ namespace Antmicro.Renode.Peripherals.PWM
                 parent.PWMOut[2 * index + 1].Set(dcB > 0);
             }
 
-            public uint GetCurrentCounter() => (uint)timer.Value;
-            public void SetCounter(ushort val) => timer.Value = val;
+            public uint GetCurrentCounter()
+            {
+                if (timer.Value >= (ulong)activeTop + 1) return 0;
+                return (uint)timer.Value;
+            }
+            public void SetCounter(ushort val)
+            {
+                timer.Value = (ulong)val;
+                parent.Log(LogLevel.Info, "PWM Slice {0}: Counter manually set to {1}", index, val);
+            }
 
             public double DutyCycleA => (double)activeCompareA / (activeTop + 1);
             public double DutyCycleB => (double)activeCompareB / (activeTop + 1);
@@ -278,6 +397,7 @@ namespace Antmicro.Renode.Peripherals.PWM
             public uint activeCompareB;
             public uint activeTop;
 
+            private bool lastInputState;
             private readonly LimitTimer timer;
             private readonly RP2040PWM parent;
             private readonly int index;


### PR DESCRIPTION
I have implemented all missing features for "Phase 13: Full PWM Feature Support" in the RP2040 Renode emulation and firmware.

Key changes:
1. **Renode Peripheral (`rp2040_pwm.cs`)**:
   - Implemented `IGPIOReceiver` to allow PWM slices to receive input signals (simulating the B pins).
   - Added `DIVMODE` support for LEVEL, RISE, and FALL input modes.
   - Implemented `PH_ADV` and `PH_RET` strobe bits for manual phase adjustment.
   - Added 8 DREQ output signals (one per slice) and implemented pulsing on counter wrap.
   - Fixed an off-by-one error where the counter limit was `TOP` instead of `TOP + 1`.
2. **Firmware (`src/main.cpp`)**:
   - Added UART command 'J' to configure a PWM slice in RISE mode.
   - Added UART command 'N' to report the current PWM counter value.
   - Added UART command 'L' to trigger a phase advancement (strobe PH_ADV).
3. **Hardware Wiring (`rp2040.repl`)**:
   - Connected the new PWM DREQ outputs (indices 24-31) to the DMA controller.
4. **Verification**:
   - Added new test cases to `test/full_suite.robot` that use `ExternalTrigger` to simulate edges and verify the PWM counter increments correctly in RISE mode and during phase adjustment.
   - Successfully ran the entire suite with `renode-test`.
5. **Roadmap**:
   - Updated `ROADMAP.md` to reflect completion of Phase 13.

Fixes #148

---
*PR created automatically by Jules for task [12036397036330875472](https://jules.google.com/task/12036397036330875472) started by @chatelao*