### PR TITLE
DMA Ring Buffer and Sniffer Refinements

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -56,12 +56,13 @@ The final plan to implement the `CONCEPT.md` and `DESIGN.md` to achieve the top 
 
 ## Phase 12: Advanced Simulation & Performance
 - [x] Draft `docs/DMA_CONCEPT.md` for DMA integration [2026-05-04]
-- [ ] Implement advanced DMA features (Pacing Timers, Debug Registers)
+- [x] Implement advanced DMA features (Pacing Timers, Debug Registers, Ring Buffers)
     - [x] Implement `N_CHANNELS` register for channel discovery [2026-05-08]
     - [x] Implement `CHAN_ABORT` logic for halting transfers [2026-05-08]
     - [x] Implement `TIMER0`-`TIMER3` for periodic pacing requests [2026-05-09]
     - [x] Add Debug registers (`DBG_CTDREQ`, `DBG_TCR`) [2026-05-10]
-- [x] Implement DMA-based data transfer examples (CRC calculation, Block move) [2026-05-06]
+    - [x] Implement correct Ring Buffer wrapping and Sniffer Global Enable [2026-05-23]
+- [x] Implement DMA-based data transfer examples (CRC calculation, Block move, Ring buffers) [2026-05-06]
 - [x] Create Robot Framework tests for basic DMA transfers and interrupts [2026-05-06]
 - [ ] Optimize Renode simulation parameters for better host performance
 - [ ] Expand `full_suite.robot` with advanced stress tests

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -515,6 +515,60 @@ void loop() {
 
       dma_channel_unclaim(dma_chan);
       Serial1.flush();
+    } else if (incomingByte == 'C') {
+      // DMA Ring Buffer and Sniffer Test
+      static uint8_t ring_buffer[256] __attribute__((aligned(256)));
+      static uint8_t target_buffer[256];
+      for (int i = 0; i < 256; i++) ring_buffer[i] = i;
+      memset(target_buffer, 0, 256);
+
+      int dma_chan = dma_claim_unused_channel(true);
+      dma_channel_config c = dma_channel_get_default_config(dma_chan);
+      channel_config_set_transfer_data_size(&c, DMA_SIZE_8);
+      channel_config_set_read_increment(&c, true);
+      channel_config_set_write_increment(&c, true);
+      // Ring on read side, size 256 (log2(256) = 8)
+      channel_config_set_ring(&c, false, 8);
+      // Sniffer enable
+      channel_config_set_sniff_enable(&c, true);
+
+      // Configure sniffer for Sum
+      dma_sniffer_enable(dma_chan, DMA_SNIFF_CTRL_CALC_VALUE_SUM, true);
+      dma_hw->sniff_data = 0;
+
+      // Transfer 512 bytes (should wrap twice)
+      dma_channel_configure(
+          dma_chan,
+          &c,
+          target_buffer,
+          ring_buffer,
+          512,
+          true
+      );
+
+      dma_channel_wait_for_finish_blocking(dma_chan);
+
+      uint32_t sniff_sum = dma_hw->sniff_data;
+      Serial1.printf("DMA Ring Test: SUM=%u\n", (unsigned int)sniff_sum);
+
+      // Test sniffer global disable
+      dma_sniffer_set_output_reverse_enabled(false); // Just to access sniffer registers
+      dma_hw->sniff_ctrl &= ~DMA_SNIFF_CTRL_EN_BITS; // Global disable
+      dma_hw->sniff_data = 0;
+
+      dma_channel_configure(
+          dma_chan,
+          &c,
+          target_buffer,
+          ring_buffer,
+          10,
+          true
+      );
+      dma_channel_wait_for_finish_blocking(dma_chan);
+      Serial1.printf("DMA Sniff Disable Test: SUM=%u\n", (unsigned int)dma_hw->sniff_data);
+
+      dma_channel_unclaim(dma_chan);
+      Serial1.flush();
     } else {
       Serial1.print("Echo: ");
       Serial1.println(incomingByte);

--- a/test/dma_ring.robot
+++ b/test/dma_ring.robot
@@ -1,0 +1,33 @@
+*** Settings ***
+Suite Setup                   Setup
+Suite Teardown                Teardown
+Test Teardown                 Test Teardown
+Resource                      ${RENODEKEYWORDS}
+
+*** Variables ***
+${UART}                       sysbus.uart0
+${FIRMWARE}                   ${CURDIR}/../.pio/build/seeed-xiao-rp2040/firmware.elf
+${RESC}                       ${CURDIR}/renode-config/run_xiao.resc
+
+*** Test Cases ***
+Should Verify DMA Ring Buffer and Sniffer Global Enable
+    [Documentation]           Verifies that DMA ring wrapping works correctly and sniffer respects global enable.
+    Create Machine
+    Start Emulation
+
+    Wait For Line On Uart     UART Bidirectional Communication Ready
+
+    # Trigger 'C' command for Ring and Sniffer tests
+    Write Char On Uart        C
+
+    # 0-255 sum is 32640. Wrapping twice (512 bytes) should be 65280.
+    Wait For Line On Uart     DMA Ring Test: SUM=65280
+
+    # Global disable should prevent sniffer from updating even if channel sniff is enabled
+    Wait For Line On Uart     DMA Sniff Disable Test: SUM=0
+
+*** Keywords ***
+Create Machine
+    Execute Command           $global.TEST_FILE = @${FIRMWARE}
+    Execute Command           include @${RESC}
+    Create Terminal Tester    ${UART}

--- a/test/renode-config/emulation/peripherals/dma/rpdma.cs
+++ b/test/renode-config/emulation/peripherals/dma/rpdma.cs
@@ -569,7 +569,7 @@ namespace Antmicro.Renode.Peripherals.DMA
           RPXXXXDmaRequest request = CreateRequest(paced);
           parent.channelFinished[channelNumber] = false;
           ResponseWithCrc response;
-          if (sniffEnable.Value && (uint)parent.sniffChannel == (uint)channelNumber)
+          if (parent.sniffEnable.Value && sniffEnable.Value && (uint)parent.sniffChannel == (uint)channelNumber)
           {
             ChecksumRequest.Type checksumType = ChecksumRequest.Type.Crc32;
             switch (this.parent.sniffCalcType.Value)

--- a/test/renode-config/emulation/peripherals/dma/rpdma_engine.cs
+++ b/test/renode-config/emulation/peripherals/dma/rpdma_engine.cs
@@ -120,7 +120,7 @@ namespace Antmicro.Renode.Peripherals.DMA
           // Transfer Units |  1  |  2  |  3  |  4  |
           // Source         |  A  |  B  |  C  |  D  |
           // Copied         |  A  |  B  |  C  |  D  |
-          response.ReadAddress += (ulong)ReadFromMemory(sourceAddress + readOffset, buffer, request.request.Size, context, request.ringWrite == false ? request.ringSize : 0);
+          response.ReadAddress = ReadFromMemory(sourceAddress + readOffset, buffer, request.request.Size, context, request.ringWrite == false ? request.ringSize : 0);
         }
         else
         {
@@ -135,23 +135,26 @@ namespace Antmicro.Renode.Peripherals.DMA
       {
         // Read from peripherals
         var transferred = 0;
-        var offset = 0UL;
+        var currentReadAddr = sourceAddress + readOffset;
+        int ringSize = request.ringWrite == false ? request.ringSize : 0;
+        ulong mask = (ulong)ringSize - 1;
+        ulong baseAddr = currentReadAddr & ~mask;
+
         while (transferred < request.request.Size)
         {
-          var readAddress = sourceAddress + offset + readOffset;
           switch (request.request.ReadTransferType)
           {
             case TransferType.Byte:
-              buffer[transferred] = sysbus.ReadByte(readAddress, context);
+              buffer[transferred] = sysbus.ReadByte(currentReadAddr, context);
               break;
             case TransferType.Word:
-              BitConverter.GetBytes(sysbus.ReadWord(readAddress, context)).CopyTo(buffer, transferred);
+              BitConverter.GetBytes(sysbus.ReadWord(currentReadAddr, context)).CopyTo(buffer, transferred);
               break;
             case TransferType.DoubleWord:
-              BitConverter.GetBytes(sysbus.ReadDoubleWord(readAddress, context)).CopyTo(buffer, transferred);
+              BitConverter.GetBytes(sysbus.ReadDoubleWord(currentReadAddr, context)).CopyTo(buffer, transferred);
               break;
             case TransferType.QuadWord:
-              BitConverter.GetBytes(sysbus.ReadQuadWord(readAddress, context)).CopyTo(buffer, transferred);
+              BitConverter.GetBytes(sysbus.ReadQuadWord(currentReadAddr, context)).CopyTo(buffer, transferred);
               break;
             default:
               throw new ArgumentOutOfRangeException($"Requested read transfer size: {request.request.ReadTransferType} is not supported by DmaEngine");
@@ -159,13 +162,15 @@ namespace Antmicro.Renode.Peripherals.DMA
           transferred += readLengthInBytes;
           if (request.request.IncrementReadAddress)
           {
-            offset += request.request.SourceIncrementStep;
-            response.ReadAddress += request.request.SourceIncrementStep;
-            if (request.ringSize != 0 && request.ringWrite == false && offset == (ulong)request.ringSize)
+            if (ringSize != 0)
             {
-              offset = 0;
-              response.ReadAddress = request.request.Source.Address;
+                currentReadAddr = baseAddr | ((currentReadAddr + request.request.SourceIncrementStep) & mask);
             }
+            else
+            {
+                currentReadAddr += request.request.SourceIncrementStep;
+            }
+            response.ReadAddress = currentReadAddr;
           }
         }
       }
@@ -240,12 +245,13 @@ namespace Antmicro.Renode.Peripherals.DMA
       {
         if (request.request.IncrementWriteAddress)
         {
+          int ringSize = request.ringWrite == true ? request.ringSize : 0;
           if (request.request.IncrementReadAddress || !isSourceContinuousMemory)
           {
             // Transfer Units |  1  |  2  |  3  |  4  |
             // Source         |  A  |  B  |  C  |  D  |
             // Destination    |  A  |  B  |  C  |  D  |
-            WriteToMemory(destinationAddress + writeOffset, buffer, context, request.ringWrite == true ? request.ringSize : 0);
+            response.WriteAddress = WriteToMemory(destinationAddress + writeOffset, buffer, context, ringSize);
           }
           else
           {
@@ -256,26 +262,34 @@ namespace Antmicro.Renode.Peripherals.DMA
             var chunkStartOffset = 0UL;
             var chunk = new byte[writeLengthInBytes];
             Array.Copy(buffer, 0, chunk, 0, writeLengthInBytes);
+
+            ulong currentWriteAddr = destinationAddress + writeOffset;
+            ulong mask = (ulong)ringSize - 1;
+            ulong baseAddr = currentWriteAddr & ~mask;
+
             while (chunkStartOffset < (ulong)request.request.Size)
             {
-              var writeAddress = destinationAddress + chunkStartOffset;
-              ulong size = (ulong)chunk.Length;
-              if (request.ringSize != 0 && request.ringWrite == true && chunkStartOffset % (ulong)request.ringSize != 0)
+              int chunkSize = writeLengthInBytes;
+              if (ringSize != 0)
               {
-                // write just what left till full ring
-                size = (ulong)request.ringSize - chunkStartOffset % (ulong)request.ringSize;
+                  ulong offsetInRing = currentWriteAddr & mask;
+                  int bytesToBoundary = ringSize - (int)offsetInRing;
+                  chunkSize = Math.Min(writeLengthInBytes, bytesToBoundary);
               }
-              sysbus.WriteBytes(chunk, writeAddress + writeOffset, (long)size, false, context: context);
-              chunkStartOffset += size;
+
+              sysbus.WriteBytes(chunk, currentWriteAddr, (long)chunkSize, false, context: context);
+
+              if (ringSize != 0)
+              {
+                  currentWriteAddr = baseAddr | ((currentWriteAddr + (ulong)chunkSize) & mask);
+              }
+              else
+              {
+                  currentWriteAddr += (ulong)chunkSize;
+              }
+              chunkStartOffset += (ulong)chunkSize;
             }
-          }
-          if (request.ringSize != 0 && request.ringWrite == true)
-          {
-            response.WriteAddress += (ulong)request.request.Size % (ulong)request.ringSize;
-          }
-          else
-          {
-            response.WriteAddress += (ulong)request.request.Size;
+            response.WriteAddress = currentWriteAddr;
           }
         }
         else
@@ -295,22 +309,26 @@ namespace Antmicro.Renode.Peripherals.DMA
       {
         // Write to peripheral
         var transferred = 0;
-        var offset = 0UL + writeOffset;
+        var currentWriteAddr = destinationAddress + writeOffset;
+        int ringSize = request.ringWrite == true ? request.ringSize : 0;
+        ulong mask = (ulong)ringSize - 1;
+        ulong baseAddr = currentWriteAddr & ~mask;
+
         while (transferred < request.request.Size)
         {
           switch (request.request.WriteTransferType)
           {
             case TransferType.Byte:
-              sysbus.WriteByte(destinationAddress + offset, buffer[transferred], context);
+              sysbus.WriteByte(currentWriteAddr, buffer[transferred], context);
               break;
             case TransferType.Word:
-              sysbus.WriteWord(destinationAddress + offset, BitConverter.ToUInt16(buffer, transferred), context);
+              sysbus.WriteWord(currentWriteAddr, BitConverter.ToUInt16(buffer, transferred), context);
               break;
             case TransferType.DoubleWord:
-              sysbus.WriteDoubleWord(destinationAddress + offset, BitConverter.ToUInt32(buffer, transferred), context);
+              sysbus.WriteDoubleWord(currentWriteAddr, BitConverter.ToUInt32(buffer, transferred), context);
               break;
             case TransferType.QuadWord:
-              sysbus.WriteQuadWord(destinationAddress + offset, BitConverter.ToUInt64(buffer, transferred), context);
+              sysbus.WriteQuadWord(currentWriteAddr, BitConverter.ToUInt64(buffer, transferred), context);
               break;
             default:
               throw new ArgumentOutOfRangeException($"Requested write transfer size: {request.request.WriteTransferType} is not supported by DmaEngine");
@@ -318,14 +336,15 @@ namespace Antmicro.Renode.Peripherals.DMA
           transferred += writeLengthInBytes;
           if (request.request.IncrementWriteAddress)
           {
-            offset += request.request.DestinationIncrementStep;
-            response.WriteAddress += request.request.DestinationIncrementStep;
-            // since starting address must be aligned to ring size, when offset is ring size, we can just substract it from address
-            if (request.ringSize != 0 && request.ringWrite == true && (offset % (ulong)request.ringSize == 0))
+            if (ringSize != 0)
             {
-              response.WriteAddress -= (ulong)request.ringSize;
-              offset = writeOffset;
+                currentWriteAddr = baseAddr | ((currentWriteAddr + request.request.DestinationIncrementStep) & mask);
             }
+            else
+            {
+                currentWriteAddr += request.request.DestinationIncrementStep;
+            }
+            response.WriteAddress = currentWriteAddr;
           }
         }
       }
@@ -334,42 +353,61 @@ namespace Antmicro.Renode.Peripherals.DMA
       return responseWithCrc;
     }
 
-    private int ReadFromMemory(ulong sourceAddress, byte[] buffer, int size, CPU.ICPU context, int ringSize)
+    private ulong ReadFromMemory(ulong sourceAddress, byte[] buffer, int size, CPU.ICPU context, int ringSize)
     {
       if (ringSize == 0)
       {
         sysbus.ReadBytes(sourceAddress, size, buffer, 0, context: context);
-        return size;
+        return sourceAddress + (ulong)size;
       }
+
+      ulong mask = (ulong)ringSize - 1;
+      ulong baseAddr = sourceAddress & ~mask;
+      ulong currentAddr = sourceAddress;
 
       int transferred = 0;
       while (transferred < size)
       {
-        int chunkSize = Math.Min(size - transferred, ringSize);
-        sysbus.ReadBytes(sourceAddress, chunkSize, buffer, transferred, context: context);
+        ulong offsetInRing = currentAddr & mask;
+        int bytesToBoundary = ringSize - (int)offsetInRing;
+        int chunkSize = Math.Min(size - transferred, bytesToBoundary);
+
+        sysbus.ReadBytes(currentAddr, chunkSize, buffer, transferred, context: context);
+
         transferred += chunkSize;
+        currentAddr = baseAddr | ((currentAddr + (ulong)chunkSize) & mask);
       }
-      return size % ringSize;
+      return currentAddr;
     }
-    private int WriteToMemory(ulong destinationAddress, byte[] buffer, CPU.ICPU context, int ringSize)
+
+    private ulong WriteToMemory(ulong destinationAddress, byte[] buffer, CPU.ICPU context, int ringSize)
     {
       int size = buffer.Length;
       if (ringSize == 0)
       {
         sysbus.WriteBytes(buffer, destinationAddress, context: context);
-        return size;
+        return destinationAddress + (ulong)size;
       }
+
+      ulong mask = (ulong)ringSize - 1;
+      ulong baseAddr = destinationAddress & ~mask;
+      ulong currentAddr = destinationAddress;
 
       int transferred = 0;
       while (transferred < size)
       {
-        int chunkSize = Math.Min(size - transferred, ringSize);
+        ulong offsetInRing = currentAddr & mask;
+        int bytesToBoundary = ringSize - (int)offsetInRing;
+        int chunkSize = Math.Min(size - transferred, bytesToBoundary);
+
         var chunk = new byte[chunkSize];
         Array.Copy(buffer, transferred, chunk, 0, chunkSize);
-        sysbus.WriteBytes(chunk, destinationAddress, context: context);
+        sysbus.WriteBytes(chunk, currentAddr, context: context);
+
         transferred += chunkSize;
+        currentAddr = baseAddr | ((currentAddr + (ulong)chunkSize) & mask);
       }
-      return size % ringSize;
+      return currentAddr;
     }
 
 


### PR DESCRIPTION
This PR implements correct DMA Ring Buffer address wrapping and Sniffer Global Enable logic in the Renode RP2040 simulation. 

Key changes:
1.  **RPDmaEngine.cs**: Modified `ReadFromMemory`, `WriteToMemory`, and peripheral transfer loops to use bitwise masks for $2^{RING\_SIZE}$ boundary wrapping, ensuring hardware-accurate behavior.
2.  **RPDMA.cs**: Updated `ProcessTransfer` to verify the global `SNIFF_CTRL.EN` bit before performing checksum calculations, and fixed address update logic.
3.  **main.cpp**: Added a new UART command 'C' that configures a 256-byte aligned ring buffer, performs a 512-byte transfer (wrapping twice), and verifies the sniffer sum output. It also tests the global sniffer disable functionality.
4.  **test/dma_ring.robot**: A new Robot Framework test suite that validates these features in the Renode environment.
5.  **ROADMAP.md**: Marked these DMA refinements as completed under Phase 12.

All tests, including the new `dma_ring.robot` and the existing `full_suite.robot`, passed successfully.

Fixes #152

---
*PR created automatically by Jules for task [8869314238730844039](https://jules.google.com/task/8869314238730844039) started by @chatelao*