### PR TITLE
PIO DMA and IRQ Routing Implementation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,1 +1,107 @@
-docs/ROADMAP.md
+# Roadmap
+
+The final plan to implement the `CONCEPT.md` and `DESIGN.md` to achieve the top goal.
+
+## Phase 4: Peripheral Implementation
+### ADC Support
+- [x] Configure ADC in PlatformIO (Arduino/Pico SDK) [2026-05-01]
+- [x] Map ADC pins in Renode `.repl` file [2026-05-01]
+- [x] Create Robot Framework test for ADC reading with simulated analog values [2026-05-01]
+
+### PWM Support
+- [x] Configure PWM in PlatformIO [2026-05-22]
+- [x] Implement basic PWM peripheral model in Renode (register stub) [2026-05-01]
+- [x] Implement PWM slice register handling (CSR, DIV, CTR, TOP, CC) [2026-05-01]
+- [x] Map PWM pins in Renode `.repl` file [2026-05-22]
+   - [x] Create Robot Framework test for PWM frequency and duty cycle verification [2026-05-22]
+
+### Interrupt Support
+- [x] Configure NVIC and interrupt vectors in Renode [2026-05-02]
+- [x] Implement basic interrupt handling in firmware [2026-05-02]
+- [x] Create Robot Framework test for interrupt-driven events [2026-05-02]
+
+### Timer Support
+- [x] Configure RP2040 Timer peripheral in Renode [2026-05-03]
+- [x] Implement timer-based delays and alarms in firmware [2026-05-03]
+- [x] Create Robot Framework test for timer accuracy and periodic interrupts [2026-05-03]
+
+## Phase 7: I2C Peripheral Support
+- [x] Implement I2C firmware driver using Arduino Wire or Pico SDK [2026-05-04]
+- [x] Configure I2C peripherals in Renode `.repl` and `.resc` files [2026-05-04]
+- [x] Integrate an existing I2C peripheral model (e.g., PCF8523 or BMP280) for verification [2026-05-04]
+- [x] Create Robot Framework tests for I2C communication and sensor reading [2026-05-04]
+
+## Phase 8: Motor Control and bEMF Support
+- [x] Draft `docs/BEMF_LOOP.md` for bEMF loop calculation concept [2026-05-05]
+- [x] Phase 8.1: Integration of `MotorModel` Renode peripheral [2026-05-06]
+    - [x] Create `MotorModel` Renode peripheral model [2026-05-06]
+    - [x] Wire the `MotorModel` to PWM outputs and ADC input channels in the XIAO RP2040 `.repl` configuration. [2026-05-06]
+    - [x] Implement UART command 'G' in firmware to read Motor ADC channel. [2026-05-06]
+    - [x] Verify `MotorModel` integration with Robot Framework tests. [2026-05-06]
+- [x] Phase 8.2: Firmware logic for high-precision ADC/PWM synchronization [2026-05-06]
+    - [x] Implement synchronization using PWM wrap interrupts.
+    - [x] Ensure sample timing alignment with PWM cycles.
+- [ ] Phase 8.3: BEMF zero-crossing detection logic
+    - [ ] Develop the BEMF zero-crossing detection algorithm and commutation state machine.
+- [ ] Create a UART-based logging system for BEMF data and a host-side tool (e.g., Python/Matplotlib) for graphical analysis.
+- [ ] Add Robot Framework test cases to verify closed-loop motor commutation and speed stability.
+
+## Phase 11: PIO Integration
+- [x] Draft `docs/PIO_CONCEPT.md` for PIO integration [2026-05-03]
+- [x] Implement PIO (Programmable I/O) state machine examples in firmware [2026-05-04]
+- [x] Connect PIO outputs to XIAO RP2040 pins in Renode `.repl` [2026-05-04]
+- [x] Implement DMA requests (DREQ) and IRQ routing for PIO in Renode [2026-05-23]
+    - [x] Implement `INumberedGPIOOutput` in `RP2040PIOCPU` [2026-05-23]
+    - [x] Implement signal update logic for FIFOs (DREQ) and Interrupts (IRQ) [2026-05-23]
+    - [x] Wire PIO0 and PIO1 signals in `rp2040.repl` [2026-05-23]
+- [x] Reuse `hello_pio` and `pio_blink` tests from `Renode_RP2040` [2026-05-06]
+- [x] Create Robot Framework tests for PIO driving XIAO Seeed RP2040 pins [2026-05-06]
+
+## Phase 12: Advanced Simulation & Performance
+- [x] Draft `docs/DMA_CONCEPT.md` for DMA integration [2026-05-04]
+- [x] Implement advanced DMA features (Pacing Timers, Debug Registers, Ring Buffers)
+    - [x] Implement `N_CHANNELS` register for channel discovery [2026-05-08]
+    - [x] Implement `CHAN_ABORT` logic for halting transfers [2026-05-08]
+    - [x] Implement `TIMER0`-`TIMER3` for periodic pacing requests [2026-05-09]
+    - [x] Add Debug registers (`DBG_CTDREQ`, `DBG_TCR`) [2026-05-10]
+    - [x] Implement correct Ring Buffer wrapping and Sniffer Global Enable [2026-05-23]
+- [x] Implement DMA-based data transfer examples (CRC calculation, Block move, Ring buffers) [2026-05-06]
+- [x] Create Robot Framework tests for basic DMA transfers and interrupts [2026-05-06]
+- [ ] Optimize Renode simulation parameters for better host performance
+- [ ] Expand `full_suite.robot` with advanced stress tests
+
+## Phase 13: Full PWM Feature Support
+- [x] Implement 16-bit dynamic counter in `RP2040PWM` Renode model [2026-05-06]
+- [x] Implement double buffering for `CC` and `TOP` registers (latched update on wrap) [2026-05-06]
+- [x] Implement `DIVMODE` support for LEVEL, RISE, and FALL input modes [2026-05-09]
+- [x] Implement IRQ and DREQ signal assertion on counter wrap [2026-05-09]
+- [x] Implement `PH_ADV` and `PH_RET` phase adjustment logic [2026-05-09]
+- [x] Create Robot Framework tests for advanced PWM features (interrupts, inputs) [2026-05-09]
+
+## Phase 14: Full ADC Feature Support
+- [x] Fix round-robin logic in `RP2040ADC` to correctly cycle through enabled channels [2026-05-04]
+- [x] Implement error generation logic and propagate `ERR` bits to status and FIFO [2026-05-04]
+- [x] Correct `READY` flag behavior to remain high during pacing timer delays [2026-05-04]
+- [x] Refactor pacing timer to define the total sampling interval (96 cycles vs `DIV` setting) [2026-05-04]
+- [x] Implement correct `FIFO` register bit packing including bit 15 (`ERR`) [2026-05-04]
+- [x] Align `DMARequest` (DREQ) signaling with `FCS.THRESH` and `FCS.DREQ_EN` logic [2026-05-04]
+- [x] Fix stability of ADC error detection and threshold logic tests [2026-05-05]
+
+## Phase 16: System Resets and Power Management
+- [ ] Implement `RP2040Resets` Renode model for peripheral reset control
+- [ ] Implement `RP2040Power` Renode model for power-on reset and sleep states
+- [ ] Create firmware examples for peripheral reset and low-power modes
+- [ ] Create Robot Framework tests for reset and power management
+
+## Phase 17: USB Support
+- [ ] Implement `RP2040USB` Renode model for USB controller
+- [ ] Integrate USB core logic and endpoint management
+- [ ] Create firmware examples for USB Serial and HID
+- [ ] Create Robot Framework tests for USB communication
+
+## Phase 10: Transition to Pico SDK (Technical Debt)
+- [ ] Setup Pico SDK build environment in `src/install.sh`
+- [ ] Port UART and GPIO drivers to native Pico SDK
+- [ ] Port ADC and PWM drivers to native Pico SDK
+- [ ] Port Timer and Interrupt handling to native Pico SDK
+- [ ] Verify full system functionality with native Pico SDK firmware

--- a/test/renode-config/cores/rp2040.repl
+++ b/test/renode-config/cores/rp2040.repl
@@ -68,6 +68,30 @@ piocpu1: CPU.RP2040PIOCPU @ sysbus
     id: 1
     clocks: clocks
 
+piocpu0:
+    0 -> nvic0@7
+    1 -> nvic0@8
+    2 -> dma@0
+    3 -> dma@1
+    4 -> dma@2
+    5 -> dma@3
+    6 -> dma@4
+    7 -> dma@5
+    8 -> dma@6
+    9 -> dma@7
+
+piocpu1:
+    0 -> nvic0@9
+    1 -> nvic0@10
+    2 -> dma@8
+    3 -> dma@9
+    4 -> dma@10
+    5 -> dma@11
+    6 -> dma@12
+    7 -> dma@13
+    8 -> dma@14
+    9 -> dma@15
+
 // raspberrypi,rp2040 overlay
 
 sysbus:

--- a/test/renode-config/emulation/peripherals/pio/rp2040_pio.cs
+++ b/test/renode-config/emulation/peripherals/pio/rp2040_pio.cs
@@ -1,5 +1,7 @@
 using Antmicro.Renode.Core;
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using Antmicro.Renode.Logging;
 
@@ -37,7 +39,7 @@ namespace Antmicro.Renode.Peripherals.CPU
     // parts of this class can be left unmodified;
     // to integrate an external simulator you need to
     // look for comments in the code below
-    public class RP2040PIOCPU : BaseCPU, IRP2040Peripheral, IGPIOReceiver, ITimeSink, IDisposable, IDoubleWordPeripheral, IKnownSize
+    public class RP2040PIOCPU : BaseCPU, IRP2040Peripheral, IGPIOReceiver, ITimeSink, IDisposable, IDoubleWordPeripheral, IKnownSize, INumberedGPIOOutput
     {
         private static string GetSourceFileDirectory([CallerFilePath] string sourceFilePath = "")
         {
@@ -95,28 +97,67 @@ namespace Antmicro.Renode.Peripherals.CPU
             gpio.ReevaluatePioActions.Add((uint steps) =>
             {
                 totalExecutedInstructions += PioExecute(pioId, steps);
+                UpdateSignals();
             });
             clocks.OnSystemClockChange(UpdateClocks);
 
+            var innerConnections = new Dictionary<int, IGPIO>();
+            for (int i = 0; i < 10; i++)
+            {
+                innerConnections[i] = new GPIO();
+            }
+            Connections = new ReadOnlyDictionary<int, IGPIO>(innerConnections);
+
             this.Log(LogLevel.Info, "PIO{0} successfuly created!", id);
+        }
+
+        public IReadOnlyDictionary<int, IGPIO> Connections { get; }
+
+        private void UpdateSignals()
+        {
+            // PIO Registers
+            const uint FSTAT = 0x004;
+            const uint INTS0 = 0x12c;
+            const uint INTS1 = 0x138;
+
+            uint fstat = PioReadMemory(pioId, FSTAT);
+            uint ints0 = PioReadMemory(pioId, INTS0);
+            uint ints1 = PioReadMemory(pioId, INTS1);
+
+            // Connections:
+            // 0: IRQ0, 1: IRQ1
+            // 2-5: TX DREQ (0-3), 6-9: RX DREQ (0-3)
+            Connections[0].Set((ints0 & 0xF) != 0);
+            Connections[1].Set((ints1 & 0xF) != 0);
+
+            for (int i = 0; i < 4; i++)
+            {
+                // TX FIFO Not Full (DREQ)
+                Connections[2 + i].Set((fstat & (1u << (16 + i))) == 0);
+                // RX FIFO Not Empty (DREQ)
+                Connections[6 + i].Set((fstat & (1u << (8 + i))) == 0);
+            }
         }
 
         [ConnectionRegion("XOR")]
         public virtual void WriteDoubleWordXor(long offset, uint value)
         {
             PioWriteMemory(pioId, (uint)offset, PioReadMemory(pioId, (uint)offset) ^ value);
+            UpdateSignals();
         }
 
         [ConnectionRegion("SET")]
         public virtual void WriteDoubleWordSet(long offset, uint value)
         {
             PioWriteMemory(pioId, (uint)offset, PioReadMemory(pioId, (uint)offset) | value);
+            UpdateSignals();
         }
 
         [ConnectionRegion("CLEAR")]
         public virtual void WriteDoubleWordClear(long offset, uint value)
         {
             PioWriteMemory(pioId, (uint)offset, PioReadMemory(pioId, (uint)offset) & (~value));
+            UpdateSignals();
         }
 
         [ConnectionRegion("XOR")]
@@ -162,6 +203,7 @@ namespace Antmicro.Renode.Peripherals.CPU
             instructionsExecutedThisRound = 0;
             totalExecutedInstructions = 0;
             PioReset(pioId);
+            UpdateSignals();
             // [Here goes an invocation resetting the external simulator (if needed)]
             // [This can be used to revert the internal state of the simulator to the initial form]
         }
@@ -170,7 +212,9 @@ namespace Antmicro.Renode.Peripherals.CPU
         {
             lock (this)
             {
-                return (uint)PioReadMemory(pioId, (uint)offset);
+                uint val = (uint)PioReadMemory(pioId, (uint)offset);
+                UpdateSignals();
+                return val;
             }
         }
 
@@ -179,6 +223,7 @@ namespace Antmicro.Renode.Peripherals.CPU
             lock (this)
             {
                 PioWriteMemory(pioId, (uint)offset, (uint)value);
+                UpdateSignals();
             }
         }
 


### PR DESCRIPTION
This change implements the necessary infrastructure for PIO blocks to trigger DMA transfers and interrupts within the Renode simulation.

Key modifications:
1. **RP2040PIOCPU.cs**: 
   - Added support for `INumberedGPIOOutput`.
   - Implemented `UpdateSignals()` which reads `FSTAT` (0x04) for FIFO status (DREQs) and `IRQ0_INTS`/`IRQ1_INTS` (0x12c/0x138) for interrupt status.
   - Integrated `UpdateSignals()` into the execution loop and register access handlers to ensure real-time signal accuracy.
2. **rp2040.repl**:
   - Connected `piocpu0` and `piocpu1` signals to their hardware-appropriate destinations.
   - IRQs mapped to NVIC slots 7-10.
   - DREQs mapped to DMA channels 0-15.
3. **ROADMAP.md**:
   - Expanded the PIO integration phase with detailed substeps and marked them as complete.

Fixes #154

---
*PR created automatically by Jules for task [13350954192000233322](https://jules.google.com/task/13350954192000233322) started by @chatelao*