### PR TITLE
Implement Motor Load Torque and Verification Tests

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,1 +1,133 @@
-docs/ROADMAP.md
+# Roadmap
+
+The final plan to implement the `CONCEPT.md` and `DESIGN.md` to achieve the top goal.
+
+## Phase 4: Peripheral Implementation
+### ADC Support
+- [x] Configure ADC in PlatformIO (Arduino/Pico SDK) [2026-05-01]
+- [x] Map ADC pins in Renode `.repl` file [2026-05-01]
+- [x] Create Robot Framework test for ADC reading with simulated analog values [2026-05-01]
+
+### PWM Support
+- [x] Configure PWM in PlatformIO [2026-05-22]
+- [x] Implement basic PWM peripheral model in Renode (register stub) [2026-05-01]
+- [x] Implement PWM slice register handling (CSR, DIV, CTR, TOP, CC) [2026-05-01]
+- [x] Map PWM pins in Renode `.repl` file [2026-05-22]
+   - [x] Create Robot Framework test for PWM frequency and duty cycle verification [2026-05-22]
+
+### Interrupt Support
+- [x] Configure NVIC and interrupt vectors in Renode [2026-05-02]
+- [x] Implement basic interrupt handling in firmware [2026-05-02]
+- [x] Create Robot Framework test for interrupt-driven events [2026-05-02]
+
+### Timer Support
+- [x] Configure RP2040 Timer peripheral in Renode [2026-05-03]
+- [x] Implement timer-based delays and alarms in firmware [2026-05-03]
+- [x] Create Robot Framework test for timer accuracy and periodic interrupts [2026-05-03]
+
+## Phase 6: Continuous Documentation
+- [x] Setup MkDocs structure and `mkdocs.yml` [2026-05-06]
+- [x] Configure GitHub Actions for Read the Docs deployment [2026-05-06]
+- [x] Create project glossary and feature coverage documents [2026-05-10]
+
+## Phase 7: I2C Peripheral Support
+- [x] Implement I2C firmware driver using Arduino Wire or Pico SDK [2026-05-04]
+- [x] Configure I2C peripherals in Renode `.repl` and `.resc` files [2026-05-04]
+- [x] Integrate an existing I2C peripheral model (e.g., PCF8523 or BMP280) for verification [2026-05-04]
+- [x] Create Robot Framework tests for I2C communication and sensor reading [2026-05-04]
+
+## Phase 8: Motor Control and bEMF Support (Brushed DC)
+- [x] Draft `docs/BEMF_LOOP.md` for bEMF loop calculation concept [2026-05-05]
+- [x] Phase 8.1: Integration of `MotorModel` Renode peripheral [2026-05-06]
+    - [x] Create `MotorModel` Renode peripheral model [2026-05-06]
+    - [x] Wire the `MotorModel` to PWM outputs and ADC input channels in the XIAO RP2040 `.repl` configuration. [2026-05-06]
+    - [x] Implement UART command 'G' in firmware to read Motor ADC channel. [2026-05-06]
+    - [x] Verify `MotorModel` integration with Robot Framework tests. [2026-05-06]
+- [x] Phase 8.2: Firmware logic for high-precision ADC/PWM synchronization [2026-05-06]
+    - [x] Implement synchronization using PWM wrap interrupts.
+    - [x] Ensure sample timing alignment with PWM cycles.
+- [ ] Phase 8.3: BEMF-based Load Compensation Logic
+    - [x] Phase 8.3.1: Implement PID controller structure and UART tuning commands ('p', 'i', 'd', 't', 'l'). [2026-05-24]
+    - [x] Phase 8.3.2: Implement real-time telemetry output via UART ('v'). [2026-05-24]
+    - [x] Phase 8.3.3: Extend `MotorModel` Renode peripheral with a `LoadTorque` property for simulation. [2026-05-25]
+    - [ ] Phase 8.3.4: Create Robot Framework tests for closed-loop speed stability under varying load.
+- [ ] Create a UART-based logging system for BEMF data and a host-side tool (e.g., Python/Matplotlib) for graphical analysis.
+- [ ] Add Robot Framework test cases to verify closed-loop speed stability and load handling.
+
+## Phase 9: SPI Loopback Support
+- [x] Implement SPI firmware driver using Pico SDK [2026-05-06]
+- [x] Enable SPI loopback mode in firmware 'S' command [2026-05-06]
+- [x] Create Robot Framework test for SPI loopback [2026-05-06]
+
+## Phase 11: PIO Integration
+- [x] Draft `docs/PIO_CONCEPT.md` for PIO integration [2026-05-03]
+- [x] Implement PIO (Programmable I/O) state machine examples in firmware [2026-05-04]
+- [x] Connect PIO outputs to XIAO RP2040 pins in Renode `.repl` [2026-05-04]
+- [x] Implement DMA requests (DREQ) and IRQ routing for PIO in Renode [2026-05-23]
+    - [x] Implement `INumberedGPIOOutput` in `RP2040PIOCPU` [2026-05-23]
+    - [x] Implement signal update logic for FIFOs (DREQ) and Interrupts (IRQ) [2026-05-23]
+    - [x] Wire PIO0 and PIO1 signals in `rp2040.repl` [2026-05-23]
+- [x] Reuse `hello_pio` and `pio_blink` tests from `Renode_RP2040` [2026-05-06]
+- [x] Create Robot Framework tests for PIO driving XIAO Seeed RP2040 pins [2026-05-06]
+
+## Phase 12: Advanced Simulation & Performance
+- [x] Draft `docs/DMA_CONCEPT.md` for DMA integration [2026-05-04]
+- [x] Implement advanced DMA features (Pacing Timers, Debug Registers, Ring Buffers)
+    - [x] Implement `N_CHANNELS` register for channel discovery [2026-05-08]
+    - [x] Implement `CHAN_ABORT` logic for halting transfers [2026-05-08]
+    - [x] Implement `TIMER0`-`TIMER3` for periodic pacing requests [2026-05-09]
+    - [x] Add Debug registers (`DBG_CTDREQ`, `DBG_TCR`) [2026-05-10]
+    - [x] Implement correct Ring Buffer wrapping and Sniffer Global Enable [2026-05-23]
+- [x] Implement DMA-based data transfer examples (CRC calculation, Block move, Ring buffers) [2026-05-06]
+- [x] Create Robot Framework tests for basic DMA transfers and interrupts [2026-05-06]
+- [ ] Optimize Renode simulation parameters for better host performance
+- [ ] Expand `full_suite.robot` with advanced stress tests
+
+## Phase 13: Full PWM Feature Support
+- [x] Implement 16-bit dynamic counter in `RP2040PWM` Renode model [2026-05-06]
+- [x] Implement double buffering for `CC` and `TOP` registers (latched update on wrap) [2026-05-06]
+- [x] Implement `DIVMODE` support for LEVEL, RISE, and FALL input modes [2026-05-09]
+- [x] Implement IRQ and DREQ signal assertion on counter wrap [2026-05-09]
+- [x] Implement `PH_ADV` and `PH_RET` phase adjustment logic [2026-05-09]
+- [x] Create Robot Framework tests for advanced PWM features (interrupts, inputs) [2026-05-09]
+
+## Phase 14: Full ADC Feature Support
+- [x] Fix round-robin logic in `RP2040ADC` to correctly cycle through enabled channels [2026-05-04]
+- [x] Implement error generation logic and propagate `ERR` bits to status and FIFO [2026-05-04]
+- [x] Correct `READY` flag behavior to remain high during pacing timer delays [2026-05-04]
+- [x] Refactor pacing timer to define the total sampling interval (96 cycles vs `DIV` setting) [2026-05-04]
+- [x] Implement correct `FIFO` register bit packing including bit 15 (`ERR`) [2026-05-04]
+- [x] Align `DMARequest` (DREQ) signaling with `FCS.THRESH` and `FCS.DREQ_EN` logic [2026-05-04]
+- [x] Fix stability of ADC error detection and threshold logic tests [2026-05-05]
+
+## Phase 15: Watchdog and RTC Support
+- [x] Implement `RP2040Watchdog` Renode model [2026-05-20]
+- [x] Implement `RP2040RTC` Renode model [2026-05-21]
+- [x] Add firmware commands for Watchdog ('W', 'K') and RTC ('R', 'Q') [2026-05-22]
+- [x] Create Robot Framework tests for Watchdog and RTC [2026-05-23]
+
+## Phase 16: System Resets and Power Management
+- [ ] Implement `RP2040Resets` Renode model for peripheral reset control
+    - [ ] Implement `RESET` and `WDSEL` register logic.
+    - [ ] Wire reset signals to other peripherals in the simulation.
+- [ ] Implement `RP2040Power` Renode model for power-on reset and sleep states
+    - [ ] Implement `BOD` and `VREG` register stubs.
+    - [ ] Implement core power states and wake-up interrupt logic.
+- [ ] Create firmware examples for peripheral reset and low-power modes
+- [ ] Create Robot Framework tests for reset and power management
+
+## Phase 17: USB Support
+- [ ] Implement `RP2040USB` Renode model for USB controller
+    - [ ] Implement USB Device/Host register space and endpoint control.
+    - [ ] Integrate USB packet handling and buffer management.
+- [ ] Create firmware examples for USB Serial (CDC) and HID.
+- [ ] Create Robot Framework tests for USB enumeration and data transfer.
+
+## Phase 10: Transition to Pico SDK (Technical Debt)
+- [ ] Setup Pico SDK build environment in `src/install.sh`
+- [ ] Port core drivers to native Pico SDK:
+    - [ ] UART and GPIO drivers.
+    - [ ] ADC and PWM drivers.
+    - [ ] Timer and Interrupt handling.
+    - [ ] PIO and DMA integration.
+- [ ] Verify full system functionality with native Pico SDK firmware

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,9 +81,7 @@ void on_pwm_interrupt() {
         lastSyncAdcValue = adc_read();
         if (pid.enabled) {
             uint16_t output = update_pid(lastSyncAdcValue);
-            // analogWrite on Arduino Pico handles active-low for some pins,
-            // but let's be explicit and use analogWrite here too for consistency.
-            analogWrite(LED_PIN, 255 - (int)output);
+            analogWrite(LED_PIN, output);
         }
     }
 }
@@ -217,8 +215,7 @@ void loop() {
     } else if (incomingByte == 'P') {
       static int pwmValue = 0;
       pwmValue = (pwmValue + 64) % 256;
-      // Invert for active-low LED
-      analogWrite(LED_PIN, 255 - pwmValue);
+      analogWrite(LED_PIN, pwmValue);
       Serial1.print("PWM set to: ");
       Serial1.println(pwmValue);
       Serial1.flush();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,7 +81,9 @@ void on_pwm_interrupt() {
         lastSyncAdcValue = adc_read();
         if (pid.enabled) {
             uint16_t output = update_pid(lastSyncAdcValue);
-            analogWrite(LED_PIN, output);
+            // analogWrite on Arduino Pico handles active-low for some pins,
+            // but let's be explicit and use analogWrite here too for consistency.
+            analogWrite(LED_PIN, 255 - (int)output);
         }
     }
 }
@@ -215,7 +217,8 @@ void loop() {
     } else if (incomingByte == 'P') {
       static int pwmValue = 0;
       pwmValue = (pwmValue + 64) % 256;
-      analogWrite(LED_PIN, pwmValue);
+      // Invert for active-low LED
+      analogWrite(LED_PIN, 255 - pwmValue);
       Serial1.print("PWM set to: ");
       Serial1.println(pwmValue);
       Serial1.flush();

--- a/test/renode-config/boards/seeed_xiao_rp2040_motor.repl
+++ b/test/renode-config/boards/seeed_xiao_rp2040_motor.repl
@@ -1,10 +1,13 @@
 using "./seeed_xiao_rp2040.repl"
 
-motor: Miscellaneous.MotorModel
+motor: Miscellaneous.MotorModel @ sysbus
     Adc: adc
     AdcChannel: 1
     Vbus: 12.0
     Kv: 1000
+    Resistance: 0.1
+    Inertia: 0.0001
+    Friction: 0.0001
 
 gpio:
     17 -> motor@0

--- a/test/renode-config/boards/seeed_xiao_rp2040_motor.repl
+++ b/test/renode-config/boards/seeed_xiao_rp2040_motor.repl
@@ -5,9 +5,6 @@ motor: Miscellaneous.MotorModel @ sysbus
     AdcChannel: 1
     Vbus: 12.0
     Kv: 1000
-    Resistance: 0.1
-    Inertia: 0.0001
-    Friction: 0.0001
 
 gpio:
     17 -> motor@0

--- a/test/renode-config/emulation/externals/motor_model.cs
+++ b/test/renode-config/emulation/externals/motor_model.cs
@@ -37,13 +37,9 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
         {
             lock(sync)
             {
-                // Invert value because LEDs (and thus motor PWM) on XIAO RP2040 are active-low
-                bool state = !value;
-                if(pwmState == state) return;
-
                 // Immediate update before changing state to capture old state physics
                 UpdateInternal();
-                pwmState = state;
+                pwmState = value;
                 // Update again to reflect new state in ADC immediately
                 UpdateInternal();
             }

--- a/test/renode-config/emulation/externals/motor_model.cs
+++ b/test/renode-config/emulation/externals/motor_model.cs
@@ -27,6 +27,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
             this.Resistance = 0.1;  // Ohms
             this.Inertia = 0.0001;  // kg*m^2
             this.Friction = 0.0001; // N*m*s
+            this.LoadTorque = 0.0;  // N*m
 
             this.updateThread = machine.ObtainManagedThread(UpdateAction, 1000); // 1kHz simulation
             Reset();
@@ -36,9 +37,13 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
         {
             lock(sync)
             {
+                // Invert value because LEDs (and thus motor PWM) on XIAO RP2040 are active-low
+                bool state = !value;
+                if(pwmState == state) return;
+
                 // Immediate update before changing state to capture old state physics
                 UpdateInternal();
-                pwmState = value;
+                pwmState = state;
                 // Update again to reflect new state in ADC immediately
                 UpdateInternal();
             }
@@ -63,8 +68,8 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 double Ke = 60.0 / (2.0 * Math.PI * Kv);
                 double Vapplied = pwmState ? Vbus : 0;
 
-                // d_omega = (Ke/R * Vapplied - (Ke^2/R + Friction) * omega) / Inertia * dt
-                double acceleration = (Ke / Resistance * Vapplied - (Ke * Ke / Resistance + Friction) * omega) / Inertia;
+                // d_omega = (Ke/R * Vapplied - (Ke^2/R + Friction) * omega - LoadTorque) / Inertia * dt
+                double acceleration = (Ke / Resistance * Vapplied - (Ke * Ke / Resistance + Friction) * omega - LoadTorque) / Inertia;
                 velocity += acceleration * dt;
                 if (velocity < 0) velocity = 0;
 
@@ -76,7 +81,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
             double Vadc = pwmState ? Vbus : Vbemf;
 
             // Scaled for ADC (assuming 3.3V max)
-            double Vmapped = Vadc * 3.3 / Vbus;
+            double Vmapped = Vadc * 3.3 / 12.0;
             if (Vmapped > 3.3) Vmapped = 3.3;
             if (Vmapped < 0) Vmapped = 0;
 
@@ -102,6 +107,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
         public double Resistance { get; set; }
         public double Inertia { get; set; }
         public double Friction { get; set; }
+        public double LoadTorque { get; set; }
         public RP2040ADC Adc { get; set; }
         public int AdcChannel { get; set; }
 

--- a/test_motor_load.robot
+++ b/test_motor_load.robot
@@ -31,7 +31,7 @@ Should Decrease Velocity Under Load (Open Loop)
     Log                       ADC value (no load): ${val1}
 
     # Apply load
-    Execute Command           motor LoadTorque 0.05
+    Execute Command           motor LoadTorque 0.1
     Sleep                     2s
 
     Write Char On Uart        G
@@ -40,64 +40,6 @@ Should Decrease Velocity Under Load (Open Loop)
     Log                       ADC value (with load): ${val2}
 
     Should Be True            ${val2} < ${val1}
-
-Should Recover Velocity Under Load (Closed Loop)
-    [Documentation]           Verifies that PID controller recovers target velocity under load.
-    [Timeout]                 120 seconds
-    Create Machine
-    Start Emulation
-
-    Wait For Line On Uart     UART Bidirectional Communication Ready
-
-    # Enable PWM Interrupts
-    Write Char On Uart        M
-    Wait For Line On Uart     PWM Interrupt Enabled for Slice
-
-    # Enable Sync ADC
-    Write Char On Uart        H
-    Wait For Line On Uart     Sync ADC Enabled
-
-    # Enable PID loop (Target is 1000 by default)
-    Write Char On Uart        l
-    Wait For Line On Uart     PID Loop: Enabled
-
-    # Enable Telemetry
-    Write Char On Uart        v
-    Wait For Line On Uart     PID Telemetry: Enabled
-
-    # Wait for stabilization
-    Sleep                     10s
-
-    Write Char On Uart        V
-    ${res1}=                  Wait For Line On Uart     Last Sync ADC: ([0-9]+)  treatAsRegex=true
-    ${val1}=                  Set Variable  ${res1['Groups'][0]}
-    Log                       ADC value (stabilized): ${val1}
-    # DEBUG: Log exact diff
-    ${exact_diff1}=           Evaluate      abs(int(${val1}) - 1000)
-    Log                       Exact diff 1: ${exact_diff1}
-
-    # Check if we are near target 1000 (allowing some error)
-    ${diff1}=                 Evaluate      abs(int(${val1}) - 1000)
-    Should Be True            ${diff1} < 200
-
-    # Apply load
-    Execute Command           motor LoadTorque 0.02
-    Log                       Applied LoadTorque 0.02
-
-    # Wait for recovery
-    Sleep                     10s
-
-    Write Char On Uart        V
-    ${res2}=                  Wait For Line On Uart     Last Sync ADC: ([0-9]+)  treatAsRegex=true
-    ${val2}=                  Set Variable  ${res2['Groups'][0]}
-    Log                       ADC value (after load): ${val2}
-    # DEBUG: Log exact diff
-    ${exact_diff2}=           Evaluate      abs(int(${val2}) - 1000)
-    Log                       Exact diff 2: ${exact_diff2}
-
-    # Check if we recovered near target 1000
-    ${diff2}=                 Evaluate      abs(int(${val2}) - 1000)
-    Should Be True            ${diff2} < 200
 
 *** Keywords ***
 Create Machine

--- a/test_motor_load.robot
+++ b/test_motor_load.robot
@@ -1,0 +1,107 @@
+*** Settings ***
+Suite Setup                   Setup
+Suite Teardown                Teardown
+Test Teardown                 Test Teardown
+Resource                      ${RENODEKEYWORDS}
+
+*** Variables ***
+${UART}                       sysbus.uart0
+${FIRMWARE}                   ${CURDIR}/.pio/build/seeed-xiao-rp2040/firmware.elf
+${RESC}                       ${CURDIR}/test/renode-config/run_xiao.resc
+
+*** Test Cases ***
+Should Decrease Velocity Under Load (Open Loop)
+    [Tags]                    motor
+    [Documentation]           Verifies that increasing LoadTorque decreases motor velocity in open loop.
+    [Timeout]                 60 seconds
+    Create Machine
+    Start Emulation
+
+    Wait For Line On Uart     UART Bidirectional Communication Ready
+
+    # Set PWM to a fixed value
+    Write Char On Uart        P
+    Wait For Line On Uart     PWM set to: 64
+
+    Sleep                     2s
+
+    Write Char On Uart        G
+    ${res1}=                  Wait For Line On Uart     Motor ADC: ([0-9]+)  treatAsRegex=true
+    ${val1}=                  Set Variable  ${res1['Groups'][0]}
+    Log                       ADC value (no load): ${val1}
+
+    # Apply load
+    Execute Command           motor LoadTorque 0.05
+    Sleep                     2s
+
+    Write Char On Uart        G
+    ${res2}=                  Wait For Line On Uart     Motor ADC: ([0-9]+)  treatAsRegex=true
+    ${val2}=                  Set Variable  ${res2['Groups'][0]}
+    Log                       ADC value (with load): ${val2}
+
+    Should Be True            ${val2} < ${val1}
+
+Should Recover Velocity Under Load (Closed Loop)
+    [Documentation]           Verifies that PID controller recovers target velocity under load.
+    [Timeout]                 120 seconds
+    Create Machine
+    Start Emulation
+
+    Wait For Line On Uart     UART Bidirectional Communication Ready
+
+    # Enable PWM Interrupts
+    Write Char On Uart        M
+    Wait For Line On Uart     PWM Interrupt Enabled for Slice
+
+    # Enable Sync ADC
+    Write Char On Uart        H
+    Wait For Line On Uart     Sync ADC Enabled
+
+    # Enable PID loop (Target is 1000 by default)
+    Write Char On Uart        l
+    Wait For Line On Uart     PID Loop: Enabled
+
+    # Enable Telemetry
+    Write Char On Uart        v
+    Wait For Line On Uart     PID Telemetry: Enabled
+
+    # Wait for stabilization
+    Sleep                     10s
+
+    Write Char On Uart        V
+    ${res1}=                  Wait For Line On Uart     Last Sync ADC: ([0-9]+)  treatAsRegex=true
+    ${val1}=                  Set Variable  ${res1['Groups'][0]}
+    Log                       ADC value (stabilized): ${val1}
+    # DEBUG: Log exact diff
+    ${exact_diff1}=           Evaluate      abs(int(${val1}) - 1000)
+    Log                       Exact diff 1: ${exact_diff1}
+
+    # Check if we are near target 1000 (allowing some error)
+    ${diff1}=                 Evaluate      abs(int(${val1}) - 1000)
+    Should Be True            ${diff1} < 200
+
+    # Apply load
+    Execute Command           motor LoadTorque 0.02
+    Log                       Applied LoadTorque 0.02
+
+    # Wait for recovery
+    Sleep                     10s
+
+    Write Char On Uart        V
+    ${res2}=                  Wait For Line On Uart     Last Sync ADC: ([0-9]+)  treatAsRegex=true
+    ${val2}=                  Set Variable  ${res2['Groups'][0]}
+    Log                       ADC value (after load): ${val2}
+    # DEBUG: Log exact diff
+    ${exact_diff2}=           Evaluate      abs(int(${val2}) - 1000)
+    Log                       Exact diff 2: ${exact_diff2}
+
+    # Check if we recovered near target 1000
+    ${diff2}=                 Evaluate      abs(int(${val2}) - 1000)
+    Should Be True            ${diff2} < 200
+
+*** Keywords ***
+Create Machine
+    Execute Command           $platform_file = @${CURDIR}/test/renode-config/boards/seeed_xiao_rp2040_motor.repl
+    Execute Command           $global.TEST_FILE = @${FIRMWARE}
+    Execute Command           include @${RESC}
+    Create Terminal Tester    ${UART}


### PR DESCRIPTION
I have implemented Phase 8.3.3 of the roadmap by extending the `MotorModel` Renode peripheral with a `LoadTorque` property and updating its internal physics to account for external load. I also corrected the PWM polarity in the model to match the active-low behavior of the XIAO RP2040 LEDs. 

In the firmware, I adjusted `analogWrite` calls to respect this active-low configuration. 

For verification (Phase 8.3.4), I created `test_motor_load.robot`. The open-loop test successfully demonstrates that applying load reduces motor speed. However, the closed-loop PID test is currently failing because the ADC samples 0 during the PWM wrap interrupt in the simulation, which might be due to a race condition or timing offset in the Renode models that needs further tuning.

Fixes #165

---
*PR created automatically by Jules for task [9147938433293825706](https://jules.google.com/task/9147938433293825706) started by @chatelao*