### PR TITLE
Add Vstart and Vstop to motor models and simulation

### DIFF
--- a/LOCO_MOTOR_MODELS.md
+++ b/LOCO_MOTOR_MODELS.md
@@ -4,18 +4,18 @@ This document provides 10 pre-defined motor models for H0 scale locomotives, sui
 
 ## Summary Table
 
-| Model ID | Description | Kv (RPM/V) | Resistance (Ω) | Inertia (kg·m²) | Friction (N·m·s) | Typical Behavior |
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-| **MOD_CAN** | Modern 5-Pole CAN | 1200 | 12.0 | 0.0001 | 0.0001 | Balanced, efficient, standard modern loco. |
-| **VIN_OPEN** | Vintage Open-Frame | 1500 | 5.0 | 0.0002 | 0.0005 | High torque, high stall current, noisy. |
-| **COR_PREC** | Coreless Precision | 2000 | 25.0 | 0.00001 | 0.00005 | Low inertia, very fast response, fragile. |
-| **FLY_FRGT** | Flywheel Freight | 1000 | 10.0 | 0.001 | 0.0001 | Smooth starting, long coasting (momentum). |
-| **SWT_LOW** | Low-Speed Switcher | 800 | 15.0 | 0.0001 | 0.0002 | High torque at low speeds, low top speed. |
-| **EXP_HI** | High-Speed Express | 1800 | 14.0 | 0.00015 | 0.0001 | Optimized for high-speed passenger runs. |
-| **WORN_VIN** | Worn-out Vintage | 1300 | 18.0 | 0.0002 | 0.002 | High internal friction, sluggish response. |
-| **SML_N** | Small (N-Style) | 2500 | 35.0 | 0.00005 | 0.0001 | Low torque, high RPM, used in small shays. |
-| **HVY_DFLY** | Heavy Dual-Flywheel | 1100 | 8.0 | 0.005 | 0.0002 | Massive momentum, very slow to stop. |
-| **TOY_STD** | Low-Cost Toy Motor | 2200 | 20.0 | 0.00008 | 0.0003 | Lower efficiency, erratic at low voltages. |
+| Model ID | Description | Kv (RPM/V) | Resistance (Ω) | Inertia (kg·m²) | Friction (N·m·s) | Vstart (V) | Vstop (V) | Typical Behavior |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| **MOD_CAN** | Modern 5-Pole CAN | 1200 | 12.0 | 0.0001 | 0.0001 | 1.5 | 0.8 | Balanced, efficient, standard modern loco. |
+| **VIN_OPEN** | Vintage Open-Frame | 1500 | 5.0 | 0.0002 | 0.0005 | 3.0 | 1.5 | High torque, high stall current, noisy. |
+| **COR_PREC** | Coreless Precision | 2000 | 25.0 | 0.00001 | 0.00005 | 0.5 | 0.2 | Low inertia, very fast response, fragile. |
+| **FLY_FRGT** | Flywheel Freight | 1000 | 10.0 | 0.001 | 0.0001 | 2.0 | 1.0 | Smooth starting, long coasting (momentum). |
+| **SWT_LOW** | Low-Speed Switcher | 800 | 15.0 | 0.0001 | 0.0002 | 1.2 | 0.6 | High torque at low speeds, low top speed. |
+| **EXP_HI** | High-Speed Express | 1800 | 14.0 | 0.00015 | 0.0001 | 2.0 | 1.2 | Optimized for high-speed passenger runs. |
+| **WORN_VIN** | Worn-out Vintage | 1300 | 18.0 | 0.0002 | 0.002 | 4.5 | 2.5 | High internal friction, sluggish response. |
+| **SML_N** | Small (N-Style) | 2500 | 35.0 | 0.00005 | 0.0001 | 2.5 | 1.5 | Low torque, high RPM, used in small shays. |
+| **HVY_DFLY** | Heavy Dual-Flywheel | 1100 | 8.0 | 0.005 | 0.0002 | 2.5 | 1.2 | Massive momentum, very slow to stop. |
+| **TOY_STD** | Low-Cost Toy Motor | 2200 | 20.0 | 0.00008 | 0.0003 | 3.5 | 2.0 | Lower efficiency, erratic at low voltages. |
 
 ---
 
@@ -29,6 +29,8 @@ motor: Peripherals.Motor.MotorModel @ sysbus
     Resistance: 12.0
     Inertia: 0.0001
     Friction: 0.0001
+    Vstart: 1.5
+    Vstop: 0.8
     Vbus: 12.0
     Adc: adc
     AdcChannel: 1
@@ -42,6 +44,8 @@ motor: Peripherals.Motor.MotorModel @ sysbus
     Resistance: 5.0
     Inertia: 0.0002
     Friction: 0.0005
+    Vstart: 3.0
+    Vstop: 1.5
     Vbus: 12.0
     Adc: adc
     AdcChannel: 1
@@ -55,6 +59,8 @@ motor: Peripherals.Motor.MotorModel @ sysbus
     Resistance: 25.0
     Inertia: 0.00001
     Friction: 0.00005
+    Vstart: 0.5
+    Vstop: 0.2
     Vbus: 12.0
     Adc: adc
     AdcChannel: 1
@@ -68,6 +74,8 @@ motor: Peripherals.Motor.MotorModel @ sysbus
     Resistance: 10.0
     Inertia: 0.001
     Friction: 0.0001
+    Vstart: 2.0
+    Vstop: 1.0
     Vbus: 12.0
     Adc: adc
     AdcChannel: 1
@@ -81,6 +89,8 @@ motor: Peripherals.Motor.MotorModel @ sysbus
     Resistance: 15.0
     Inertia: 0.0001
     Friction: 0.0002
+    Vstart: 1.2
+    Vstop: 0.6
     Vbus: 12.0
     Adc: adc
     AdcChannel: 1
@@ -94,6 +104,8 @@ motor: Peripherals.Motor.MotorModel @ sysbus
     Resistance: 14.0
     Inertia: 0.00015
     Friction: 0.0001
+    Vstart: 2.0
+    Vstop: 1.2
     Vbus: 12.0
     Adc: adc
     AdcChannel: 1
@@ -107,6 +119,8 @@ motor: Peripherals.Motor.MotorModel @ sysbus
     Resistance: 18.0
     Inertia: 0.0002
     Friction: 0.002
+    Vstart: 4.5
+    Vstop: 2.5
     Vbus: 12.0
     Adc: adc
     AdcChannel: 1
@@ -120,6 +134,8 @@ motor: Peripherals.Motor.MotorModel @ sysbus
     Resistance: 35.0
     Inertia: 0.00005
     Friction: 0.0001
+    Vstart: 2.5
+    Vstop: 1.5
     Vbus: 12.0
     Adc: adc
     AdcChannel: 1
@@ -133,6 +149,8 @@ motor: Peripherals.Motor.MotorModel @ sysbus
     Resistance: 8.0
     Inertia: 0.005
     Friction: 0.0002
+    Vstart: 2.5
+    Vstop: 1.2
     Vbus: 12.0
     Adc: adc
     AdcChannel: 1
@@ -146,6 +164,8 @@ motor: Peripherals.Motor.MotorModel @ sysbus
     Resistance: 20.0
     Inertia: 0.00008
     Friction: 0.0003
+    Vstart: 3.5
+    Vstop: 2.0
     Vbus: 12.0
     Adc: adc
     AdcChannel: 1

--- a/docs/LOCO_SIM.md
+++ b/docs/LOCO_SIM.md
@@ -32,6 +32,8 @@ For beginners, here is what each term represents:
 - **$\frac{d\omega}{dt}$ (Angular Acceleration):** How fast the motor's speed is increasing or decreasing.
 - **$B$ (Viscous Friction):** Internal friction that increases as the motor spins faster.
 - **$\tau_{load}$ (Load Torque):** External forces resisting the motor, such as a locomotive pulling heavy cars or climbing a steep grade.
+- **$V_{start}$ (Start Voltage):** The minimum voltage required to overcome static friction (stiction) and start the motor turning from a standstill.
+- **$V_{stop}$ (Stop Voltage):** The voltage level below which the motor's internal friction and load will cause it to stop turning. Usually lower than $V_{start}$ due to the transition from static to kinetic friction.
 
 ### Equation Breakdown
 
@@ -123,6 +125,8 @@ Standard H0 motors (like those from Mabuchi, Mashima, or modern CAN motors) typi
 | Parameter | Value Range |
 | --- | --- |
 | Operating Voltage | 0 - 12V / 14V DC |
+| Start Voltage ($V_{start}$) | 0.5V - 4.5V |
+| Stop Voltage ($V_{stop}$) | 0.2V - 2.5V |
 | No-load Speed | 8,000 - 15,000 RPM |
 | Stall Current | 0.5A - 2.0A |
 | Terminal Resistance | 5 - 25 Ohms |

--- a/test/renode-config/emulation/externals/motor_model.cs
+++ b/test/renode-config/emulation/externals/motor_model.cs
@@ -28,6 +28,8 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
             this.Inertia = 0.0001;  // kg*m^2
             this.Friction = 0.0001; // N*m*s
             this.LoadTorque = 0.0;  // N*m
+            this.Vstart = 0.0;      // Volts
+            this.Vstop = 0.0;       // Volts
 
             this.updateThread = machine.ObtainManagedThread(UpdateAction, 1000); // 1kHz simulation
             Reset();
@@ -63,6 +65,15 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 double omega = velocity;
                 double Ke = 60.0 / (2.0 * Math.PI * Kv);
                 double Vapplied = pwmState ? Vbus : 0;
+
+                if (velocity <= 0.01 && Vapplied < Vstart)
+                {
+                    Vapplied = 0;
+                }
+                else if (velocity > 0.01 && Vapplied < Vstop)
+                {
+                    Vapplied = 0;
+                }
 
                 // d_omega = (Ke/R * Vapplied - (Ke^2/R + Friction) * omega - LoadTorque) / Inertia * dt
                 double acceleration = (Ke / Resistance * Vapplied - (Ke * Ke / Resistance + Friction) * omega - LoadTorque) / Inertia;
@@ -104,6 +115,8 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
         public double Inertia { get; set; }
         public double Friction { get; set; }
         public double LoadTorque { get; set; }
+        public double Vstart { get; set; }
+        public double Vstop { get; set; }
         public RP2040ADC Adc { get; set; }
         public int AdcChannel { get; set; }
 


### PR DESCRIPTION
This change adds the requested start and stop voltage parameters (Vstart and Vstop) to the locomotive motor models documentation and the Renode simulation model. 

Key changes:
- **LOCO_MOTOR_MODELS.md**: Added `Vstart` and `Vstop` columns to the summary table and updated all 10 REPL snippets to include these properties.
- **MotorModel.cs**: Added `Vstart` and `Vstop` as configurable properties and implemented logic in `UpdateInternal` to simulate motor stiction (requiring `Vstart` to begin moving from zero) and stalling (stopping if voltage falls below `Vstop`).
- **LOCO_SIM.md**: Added definitions and typical ranges for $V_{start}$ and $V_{stop}$ to the motor physics documentation.
- **Verification**: Confirmed that the simulation remains stable and correct using `renode-test` on `test_motor.robot`.

Fixes #171

---
*PR created automatically by Jules for task [13674507122184940147](https://jules.google.com/task/13674507122184940147) started by @chatelao*