### PR TITLE
Implement RP2040Resets Peripheral Model

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,1 +1,133 @@
-docs/ROADMAP.md
+# Roadmap
+
+The final plan to implement the `CONCEPT.md` and `DESIGN.md` to achieve the top goal.
+
+## Phase 4: Peripheral Implementation
+### ADC Support
+- [x] Configure ADC in PlatformIO (Arduino/Pico SDK) [2026-05-01]
+- [x] Map ADC pins in Renode `.repl` file [2026-05-01]
+- [x] Create Robot Framework test for ADC reading with simulated analog values [2026-05-01]
+
+### PWM Support
+- [x] Configure PWM in PlatformIO [2026-05-22]
+- [x] Implement basic PWM peripheral model in Renode (register stub) [2026-05-01]
+- [x] Implement PWM slice register handling (CSR, DIV, CTR, TOP, CC) [2026-05-01]
+- [x] Map PWM pins in Renode `.repl` file [2026-05-22]
+   - [x] Create Robot Framework test for PWM frequency and duty cycle verification [2026-05-22]
+
+### Interrupt Support
+- [x] Configure NVIC and interrupt vectors in Renode [2026-05-02]
+- [x] Implement basic interrupt handling in firmware [2026-05-02]
+- [x] Create Robot Framework test for interrupt-driven events [2026-05-02]
+
+### Timer Support
+- [x] Configure RP2040 Timer peripheral in Renode [2026-05-03]
+- [x] Implement timer-based delays and alarms in firmware [2026-05-03]
+- [x] Create Robot Framework test for timer accuracy and periodic interrupts [2026-05-03]
+
+## Phase 6: Continuous Documentation
+- [x] Setup MkDocs structure and `mkdocs.yml` [2026-05-06]
+- [x] Configure GitHub Actions for Read the Docs deployment [2026-05-06]
+- [x] Create project glossary and feature coverage documents [2026-05-10]
+
+## Phase 7: I2C Peripheral Support
+- [x] Implement I2C firmware driver using Arduino Wire or Pico SDK [2026-05-04]
+- [x] Configure I2C peripherals in Renode `.repl` and `.resc` files [2026-05-04]
+- [x] Integrate an existing I2C peripheral model (e.g., PCF8523 or BMP280) for verification [2026-05-04]
+- [x] Create Robot Framework tests for I2C communication and sensor reading [2026-05-04]
+
+## Phase 8: Motor Control and bEMF Support (Brushed DC)
+- [x] Draft `docs/BEMF_LOOP.md` for bEMF loop calculation concept [2026-05-05]
+- [x] Phase 8.1: Integration of `MotorModel` Renode peripheral [2026-05-06]
+    - [x] Create `MotorModel` Renode peripheral model [2026-05-06]
+    - [x] Wire the `MotorModel` to PWM outputs and ADC input channels in the XIAO RP2040 `.repl` configuration. [2026-05-06]
+    - [x] Implement UART command 'G' in firmware to read Motor ADC channel. [2026-05-06]
+    - [x] Verify `MotorModel` integration with Robot Framework tests. [2026-05-06]
+- [x] Phase 8.2: Firmware logic for high-precision ADC/PWM synchronization [2026-05-06]
+    - [x] Implement synchronization using PWM wrap interrupts.
+    - [x] Ensure sample timing alignment with PWM cycles.
+- [x] Phase 8.3: BEMF-based Load Compensation Logic [2026-05-25]
+    - [x] Phase 8.3.1: Implement PID controller structure and UART tuning commands ('p', 'i', 'd', 't', 'l'). [2026-05-24]
+    - [x] Phase 8.3.2: Implement real-time telemetry output via UART ('v'). [2026-05-24]
+    - [x] Phase 8.3.3: Extend `MotorModel` Renode peripheral with a `LoadTorque` property for simulation. [2026-05-25]
+    - [x] Phase 8.3.4: Create Robot Framework tests for closed-loop speed stability under varying load. [2026-05-25]
+- [x] Create a UART-based logging system for BEMF data and a host-side tool (e.g., Python/Matplotlib) for graphical analysis. [2026-05-25]
+- [x] Add Robot Framework test cases to verify closed-loop speed stability and load handling. [2026-05-25]
+
+## Phase 9: SPI Loopback Support
+- [x] Implement SPI firmware driver using Pico SDK [2026-05-06]
+- [x] Enable SPI loopback mode in firmware 'S' command [2026-05-06]
+- [x] Create Robot Framework test for SPI loopback [2026-05-06]
+
+## Phase 11: PIO Integration
+- [x] Draft `docs/PIO_CONCEPT.md` for PIO integration [2026-05-03]
+- [x] Implement PIO (Programmable I/O) state machine examples in firmware [2026-05-04]
+- [x] Connect PIO outputs to XIAO RP2040 pins in Renode `.repl` [2026-05-04]
+- [x] Implement DMA requests (DREQ) and IRQ routing for PIO in Renode [2026-05-23]
+    - [x] Implement `INumberedGPIOOutput` in `RP2040PIOCPU` [2026-05-23]
+    - [x] Implement signal update logic for FIFOs (DREQ) and Interrupts (IRQ) [2026-05-23]
+    - [x] Wire PIO0 and PIO1 signals in `rp2040.repl` [2026-05-23]
+- [x] Reuse `hello_pio` and `pio_blink` tests from `Renode_RP2040` [2026-05-06]
+- [x] Create Robot Framework tests for PIO driving XIAO Seeed RP2040 pins [2026-05-06]
+
+## Phase 12: Advanced Simulation & Performance
+- [x] Draft `docs/DMA_CONCEPT.md` for DMA integration [2026-05-04]
+- [x] Implement advanced DMA features (Pacing Timers, Debug Registers, Ring Buffers)
+    - [x] Implement `N_CHANNELS` register for channel discovery [2026-05-08]
+    - [x] Implement `CHAN_ABORT` logic for halting transfers [2026-05-08]
+    - [x] Implement `TIMER0`-`TIMER3` for periodic pacing requests [2026-05-09]
+    - [x] Add Debug registers (`DBG_CTDREQ`, `DBG_TCR`) [2026-05-10]
+    - [x] Implement correct Ring Buffer wrapping and Sniffer Global Enable [2026-05-23]
+- [x] Implement DMA-based data transfer examples (CRC calculation, Block move, Ring buffers) [2026-05-06]
+- [x] Create Robot Framework tests for basic DMA transfers and interrupts [2026-05-06]
+- [ ] Optimize Renode simulation parameters for better host performance
+- [ ] Expand `full_suite.robot` with advanced stress tests
+
+## Phase 13: Full PWM Feature Support
+- [x] Implement 16-bit dynamic counter in `RP2040PWM` Renode model [2026-05-06]
+- [x] Implement double buffering for `CC` and `TOP` registers (latched update on wrap) [2026-05-06]
+- [x] Implement `DIVMODE` support for LEVEL, RISE, and FALL input modes [2026-05-09]
+- [x] Implement IRQ and DREQ signal assertion on counter wrap [2026-05-09]
+- [x] Implement `PH_ADV` and `PH_RET` phase adjustment logic [2026-05-09]
+- [x] Create Robot Framework tests for advanced PWM features (interrupts, inputs) [2026-05-09]
+
+## Phase 14: Full ADC Feature Support
+- [x] Fix round-robin logic in `RP2040ADC` to correctly cycle through enabled channels [2026-05-04]
+- [x] Implement error generation logic and propagate `ERR` bits to status and FIFO [2026-05-04]
+- [x] Correct `READY` flag behavior to remain high during pacing timer delays [2026-05-04]
+- [x] Refactor pacing timer to define the total sampling interval (96 cycles vs `DIV` setting) [2026-05-04]
+- [x] Implement correct `FIFO` register bit packing including bit 15 (`ERR`) [2026-05-04]
+- [x] Align `DMARequest` (DREQ) signaling with `FCS.THRESH` and `FCS.DREQ_EN` logic [2026-05-04]
+- [x] Fix stability of ADC error detection and threshold logic tests [2026-05-05]
+
+## Phase 15: Watchdog and RTC Support
+- [x] Implement `RP2040Watchdog` Renode model [2026-05-20]
+- [x] Implement `RP2040RTC` Renode model [2026-05-21]
+- [x] Add firmware commands for Watchdog ('W', 'K') and RTC ('R', 'Q') [2026-05-22]
+- [x] Create Robot Framework tests for Watchdog and RTC [2026-05-23]
+
+## Phase 16: System Resets and Power Management
+- [x] Implement `RP2040Resets` Renode model for peripheral reset control [2026-05-14]
+    - [x] Implement `RESET` and `WDSEL` register logic.
+    - [ ] Wire reset signals to other peripherals in the simulation.
+- [ ] Implement `RP2040Power` Renode model for power-on reset and sleep states
+    - [ ] Implement `BOD` and `VREG` register stubs.
+    - [ ] Implement core power states and wake-up interrupt logic.
+- [ ] Create firmware examples for peripheral reset and low-power modes
+- [ ] Create Robot Framework tests for reset and power management
+
+## Phase 17: USB Support
+- [ ] Implement `RP2040USB` Renode model for USB controller
+    - [ ] Implement USB Device/Host register space and endpoint control.
+    - [ ] Integrate USB packet handling and buffer management.
+- [ ] Create firmware examples for USB Serial (CDC) and HID.
+- [ ] Create Robot Framework tests for USB enumeration and data transfer.
+
+## Phase 10: Transition to Pico SDK (Technical Debt)
+- [ ] Setup Pico SDK build environment in `src/install.sh`
+- [ ] Port core drivers to native Pico SDK:
+    - [ ] UART and GPIO drivers.
+    - [ ] ADC and PWM drivers.
+    - [ ] Timer and Interrupt handling.
+    - [ ] PIO and DMA integration.
+- [ ] Verify full system functionality with native Pico SDK firmware

--- a/docs/FEATURE_COVERAGE.md
+++ b/docs/FEATURE_COVERAGE.md
@@ -19,7 +19,7 @@ This section tracks the implementation status of RP2040 features in the Renode s
 | Bootrom | ❌ | n/a |
 | Clocks | ⚠️ | Basic clock structures defined; fixed frequencies used in simulation. |
 | GPIO / Pads | ✅ | Digital IO and interrupt support verified on selected pins (e.g., GPIO 21). |
-| Resets | ❌ | n/a |
+| Resets | ⚠️ | `RESET`, `WDSEL`, and `RESET_DONE` registers implemented. |
 
 ## PIO (Programmable I/O)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -107,8 +107,8 @@ The final plan to implement the `CONCEPT.md` and `DESIGN.md` to achieve the top 
 - [x] Create Robot Framework tests for Watchdog and RTC [2026-05-23]
 
 ## Phase 16: System Resets and Power Management
-- [ ] Implement `RP2040Resets` Renode model for peripheral reset control
-    - [ ] Implement `RESET` and `WDSEL` register logic.
+- [x] Implement `RP2040Resets` Renode model for peripheral reset control [2026-05-14]
+    - [x] Implement `RESET` and `WDSEL` register logic.
     - [ ] Wire reset signals to other peripherals in the simulation.
 - [ ] Implement `RP2040Power` Renode model for power-on reset and sleep states
     - [ ] Implement `BOD` and `VREG` register stubs.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -668,6 +668,30 @@ void loop() {
 
       dma_channel_unclaim(dma_chan);
       Serial1.flush();
+    } else if (incomingByte == 'r') {
+      // Command 'r': Test RESETS peripheral (using 'r' for resets to avoid conflict with 'X')
+      volatile uint32_t *resets_base = (volatile uint32_t *)0x4000c000;
+      volatile uint32_t *reset_reg = resets_base + 0;
+      volatile uint32_t *reset_done_reg = resets_base + 2;
+
+      uint32_t initial_reset = *reset_reg;
+      uint32_t initial_done = *reset_done_reg;
+
+      // Clear reset for all (0x01ffffff are all bits that can be 1)
+      *reset_reg = 0;
+      uint32_t cleared_reset = *reset_reg;
+      uint32_t cleared_done = *reset_done_reg;
+
+      // Set reset for all
+      *reset_reg = 0x01ffffff;
+      uint32_t set_reset = *reset_reg;
+      uint32_t set_done = *reset_done_reg;
+
+      Serial1.printf("RESETS Test: INIT_R=0x%08X INIT_D=0x%08X CLR_R=0x%08X CLR_D=0x%08X SET_R=0x%08X SET_D=0x%08X\n",
+                     (unsigned int)initial_reset, (unsigned int)initial_done,
+                     (unsigned int)cleared_reset, (unsigned int)cleared_done,
+                     (unsigned int)set_reset, (unsigned int)set_done);
+      Serial1.flush();
     } else {
       // Default: Echo character back to UART
       Serial1.print("Echo: ");

--- a/test/renode-config/cores/initialize_peripherals_source.resc
+++ b/test/renode-config/cores/initialize_peripherals_source.resc
@@ -74,3 +74,5 @@ EnsureTypeIsLoaded "Antmicro.Renode.Peripherals.Miscellaneous.SegmentDisplay"
 
 
 include $ORIGIN/../emulation/peripherals/psm/rp2040_psm.cs
+
+include $ORIGIN/../emulation/peripherals/resets/rp2040_resets.cs

--- a/test/renode-config/cores/rp2040.repl
+++ b/test/renode-config/cores/rp2040.repl
@@ -94,10 +94,12 @@ piocpu1:
 
 // raspberrypi,rp2040 overlay
 
+resets: Resets.RP2040Resets @ sysbus 0x4000c000
+    address: 0x4000c000
+
 sysbus:
     init:
         ApplySVD @https://dl.antmicro.com/projects/renode/svd/RP2040.svd.gz
-        Tag <0x4000C008 4> "RESET_DONE" 0xFFFFFFFF
         Tag <0x40024004 4> "XOSC_STATUS" 0xFFFFFFFF
         Tag <0x40028000 4> "PLL_SYS_CS" 0xFFFFFFFF
         Tag <0x4002C000 4> "PLL_USB_CS" 0xFFFFFFFF

--- a/test/renode-config/emulation/peripherals/resets/rp2040_resets.cs
+++ b/test/renode-config/emulation/peripherals/resets/rp2040_resets.cs
@@ -1,0 +1,48 @@
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Core.Structure.Registers;
+using Antmicro.Renode.Logging;
+using Antmicro.Renode.Peripherals.Bus;
+
+namespace Antmicro.Renode.Peripherals.Resets
+{
+    public class RP2040Resets : RP2040PeripheralBase, IKnownSize
+    {
+        public RP2040Resets(Machine machine, ulong address) : base(machine, address)
+        {
+            DefineRegisters();
+            Reset();
+        }
+
+        public override void Reset()
+        {
+            base.Reset();
+            // Default value of RESET is 0x01ffffff (all peripherals in reset)
+            resetField.Value = 0x01ffffff;
+            wdselField.Value = 0x0;
+        }
+
+        private void DefineRegisters()
+        {
+            Registers.RESET.Define(this, 0x01ffffff)
+                .WithValueField(0, 32, out resetField, name: "RESET");
+
+            Registers.WDSEL.Define(this, 0x0)
+                .WithValueField(0, 32, out wdselField, name: "WDSEL");
+
+            Registers.RESET_DONE.Define(this, 0x0)
+                .WithValueField(0, 32, FieldMode.Read,
+                    valueProviderCallback: _ => ~resetField.Value & 0x01ffffff,
+                    name: "RESET_DONE");
+        }
+
+        private enum Registers
+        {
+            RESET = 0x0,
+            WDSEL = 0x4,
+            RESET_DONE = 0x8
+        };
+
+        IValueRegisterField resetField;
+        IValueRegisterField wdselField;
+    }
+}

--- a/test/resets.robot
+++ b/test/resets.robot
@@ -1,0 +1,27 @@
+*** Settings ***
+Suite Setup     Setup
+Suite Teardown  Teardown
+Test Setup      Reset Emulation
+Resource        ${RENODEKEYWORDS}
+
+*** Variables ***
+${UART}         sysbus.uart0
+${RESC}         ${CURDIR}/renode-config/run_xiao.resc
+
+*** Test Cases ***
+Verify RESETS Peripheral
+    [Documentation]     Verifies that the RESETS peripheral correctly reflects RESET and RESET_DONE states.
+    [Tags]              resets  rp2040
+
+    Execute Command     $global.TEST_FILE = @${FIRMWARE}
+    Execute Command     include @${RESC}
+    Create Terminal Tester    ${UART}
+
+    # Wait for UART to be ready
+    Wait For Line On Uart     UART Bidirectional Communication Ready    timeout=10
+
+    # Send 'r' command to test RESETS
+    Write Char On Uart        r
+
+    # Verify output
+    Wait For Line On Uart     RESETS Test: INIT_R=0x[0-9A-F]{8} INIT_D=0x[0-9A-F]{8} CLR_R=0x00000000 CLR_D=0x01FFFFFF SET_R=0x01FFFFFF SET_D=0x00000000    timeout=5  treatAsRegex=true


### PR DESCRIPTION
This PR implements the RP2040Resets peripheral model in Renode as a modest step from the project roadmap (Phase 16).

Key changes:
- Created `test/renode-config/emulation/peripherals/resets/rp2040_resets.cs` with the peripheral logic.
- Integrated the new peripheral into `test/renode-config/cores/rp2040.repl` and `test/renode-config/cores/initialize_peripherals_source.resc`.
- Added a firmware test command 'r' in `src/main.cpp` to interact with the RESETS peripheral.
- Added a new Robot Framework test `test/resets.robot` for automated verification.
- Updated `ROADMAP.md` and `docs/FEATURE_COVERAGE.md` to reflect the implementation status.

Verified with both the specific reset tests and the full suite to ensure no regressions.

Fixes #187

---
*PR created automatically by Jules for task [8574833338553532528](https://jules.google.com/task/8574833338553532528) started by @chatelao*